### PR TITLE
Make graph for retriever mAP clearer

### DIFF
--- a/.github/workflows/deploy-landingpage-s3.yml
+++ b/.github/workflows/deploy-landingpage-s3.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - more_documentation
+      - remove_column
     
 jobs:
   deploy:
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: more_documentation
+          ref: remove_column
       - name: Use Node.js 12
         uses: actions/setup-node@v1
         with:

--- a/src/pages/benchmarks/versions/latest/site/en/map/retriever_map.json
+++ b/src/pages/benchmarks/versions/latest/site/en/map/retriever_map.json
@@ -1,98 +1,77 @@
 {
-  "chart_type": "LineChart",
-  "title": "Retriever Accuracy",
-  "subtitle": "mAP at different number of docs",
-  "description": "Here you can see how the mean avg. precision (mAP) of the retriever decays as the number of documents increases. The set up is the same as the above querying benchmark except that a varying number of negative documents are used to fill the document store.",
-  "columns": [
-    "n_docs",
-    "BM25 / ElasticSearch",
-    "DPR / ElasticSearch",
-    "DPR / FAISS (flat)",
-    "DPR / FAISS (HSNW)"
-  ],
-  "axis": [
-     { "x": "Number of docs", "y": "mAP" }
-   ],
-  "data": [
-    {
-        "model": "DPR / ElasticSearch",
-        "n_docs": 1000,
-        "map": 0.929
-    },
-    {
-        "model": "DPR / ElasticSearch",
-        "n_docs": 10000,
-        "map": 0.898
-    },
-    {
-        "model": "DPR / ElasticSearch",
-        "n_docs": 100000,
-        "map": 0.863
-    },
-    {
-        "model": "DPR / ElasticSearch",
-        "n_docs": 500000,
-        "map": 0.805
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 1000,
-        "map": 0.929
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 10000,
-        "map": 0.898
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 100000,
-        "map": 0.863
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 500000,
-        "map": 0.805
-    },
-    {
-        "model": "BM25 / ElasticSearch",
-        "n_docs": 1000,
-        "map": 0.748
-    },
-    {
-        "model": "BM25 / ElasticSearch",
-        "n_docs": 10000,
-        "map": 0.6609999999999999
-    },
-    {
-        "model": "BM25 / ElasticSearch",
-        "n_docs": 100000,
-        "map": 0.56
-    },
-    {
-        "model": "BM25 / ElasticSearch",
-        "n_docs": 500000,
-        "map": 0.452
-    },
-    {
-        "model": "DPR / FAISS (HSNW)",
-        "n_docs": 1000,
-        "map": 0.929
-    },
-    {
-        "model": "DPR / FAISS (HSNW)",
-        "n_docs": 10000,
-        "map": 0.8959999999999999
-    },
-    {
-        "model": "DPR / FAISS (HSNW)",
-        "n_docs": 100000,
-        "map": 0.8490000000000001
-    },
-    {
-        "model": "DPR / FAISS (HSNW)",
-        "n_docs": 500000,
-        "map": 0.7659999999999999
-    }
-  ]
-}
+    "chart_type": "LineChart",
+    "title": "Retriever Accuracy",
+    "subtitle": "mAP at different number of docs",
+    "description": "Here you can see how the mean avg. precision (mAP) of the retriever decays as the number of documents increases. The set up is the same as the above querying benchmark except that a varying number of negative documents are used to fill the document store.",
+    "columns": [
+      "n_docs",
+      "BM25 / ElasticSearch",
+      "DPR / ElasticSearch or FAISS (flat)",
+      "DPR / FAISS (HSNW)"
+    ],
+    "axis": [
+       { "x": "Number of docs", "y": "mAP" }
+     ],
+    "data": [
+      {
+          "model": "DPR / ElasticSearch or FAISS (flat)",
+          "n_docs": 1000,
+          "map": 0.929
+      },
+      {
+          "model": "DPR / ElasticSearch or FAISS (flat)",
+          "n_docs": 10000,
+          "map": 0.898
+      },
+      {
+          "model": "DPR / ElasticSearch or FAISS (flat)",
+          "n_docs": 100000,
+          "map": 0.863
+      },
+      {
+          "model": "DPR / ElasticSearch or FAISS (flat)",
+          "n_docs": 500000,
+          "map": 0.805
+      },
+      {
+          "model": "BM25 / ElasticSearch",
+          "n_docs": 1000,
+          "map": 0.748
+      },
+      {
+          "model": "BM25 / ElasticSearch",
+          "n_docs": 10000,
+          "map": 0.6609999999999999
+      },
+      {
+          "model": "BM25 / ElasticSearch",
+          "n_docs": 100000,
+          "map": 0.56
+      },
+      {
+          "model": "BM25 / ElasticSearch",
+          "n_docs": 500000,
+          "map": 0.452
+      },
+      {
+          "model": "DPR / FAISS (HSNW)",
+          "n_docs": 1000,
+          "map": 0.929
+      },
+      {
+          "model": "DPR / FAISS (HSNW)",
+          "n_docs": 10000,
+          "map": 0.8959999999999999
+      },
+      {
+          "model": "DPR / FAISS (HSNW)",
+          "n_docs": 100000,
+          "map": 0.8490000000000001
+      },
+      {
+          "model": "DPR / FAISS (HSNW)",
+          "n_docs": 500000,
+          "map": 0.7659999999999999
+      }
+    ]
+  }

--- a/src/pages/bm/benchmarks.js
+++ b/src/pages/bm/benchmarks.js
@@ -230,7 +230,7 @@ const BenchMarks = ({data}) => {
                 loader={<div>Loading Chart</div>}
                 data={mapDataReader[selectedVersion]}
                 options={{
-                colors: ['#22BA99', '#FBB14B', '#49B0E4'],
+                colors: ['#22BA99', '#63C7CA', '#49B0E4', '#FBB14B'],
                 subTitle: subTitelReader[selectedVersion],
                 bars: barsReader[selectedVersion],
                 legend: "bottom"
@@ -284,7 +284,7 @@ const BenchMarks = ({data}) => {
                 data={mapDataMap[selectedVersion]}
                 options={{
                     subtitle: subTitleMap[selectedVersion],
-                    colors: ['#22BA99', '#63C7CA', '#49B0E4', '#FBB14B'],
+                    colors: ['#22BA99', '#FBB14B', '#63C7CA', '#49B0E4'],
                     hAxis: {
                       title: axisXMap[selectedVersion]
                     },

--- a/src/pages/bm/benchmarks.js
+++ b/src/pages/bm/benchmarks.js
@@ -230,7 +230,7 @@ const BenchMarks = ({data}) => {
                 loader={<div>Loading Chart</div>}
                 data={mapDataReader[selectedVersion]}
                 options={{
-                colors: ['#22BA99', '#63C7CA', '#49B0E4', '#FBB14B'],
+                colors: ['#22BA99', '#FBB14B', '#49B0E4'],
                 subTitle: subTitelReader[selectedVersion],
                 bars: barsReader[selectedVersion],
                 legend: "bottom"


### PR DESCRIPTION
The graph for retriever mAP was not very clear since two lines overlapped completely. They have now been merged as one.