### PR TITLE
Add roadmap link to zenhub webapp (not plugin)

### DIFF
--- a/docs/v0.9.0/overview/roadmap.mdx
+++ b/docs/v0.9.0/overview/roadmap.mdx
@@ -8,11 +8,12 @@ We hope this helps to clarify the direction of the open-source project and inspi
 <div style={{ marginBottom: "3rem" }} />
 
 ## How to access it
-
-### Add Zenhub Plugin
-
 We decided for Zenhub, as it allows a close integration with GitHub and real-time sharing of roadmaps and sprints.
-Once you have installed the browser plugin below, you will see additional tabs and infos on the Haystack GitHub page.
+
+Visit our Zenhub Roadmap [here](https://app.zenhub.com/workspaces/open-source-5f4fd244079454000f05f047/roadmap). You will need to be logged in with your GitHub account and Zenhub will ask for permission to integrate with your GitHub account.  
+
+### Alternative: Add Zenhub Plugin
+Once you have installed the browser plugin below, you will see additional tabs and infos directly on the Haystack GitHub page.
 
 Zenhub Plugin: https://www.zenhub.com/extension
 


### PR DESCRIPTION
There seem to be some hiccups with the zenhub plugin and permissions so that some users couldn't see the roadmap.
Let's add the link here as an alternative. 

In future: Zenhub seems to also work on a public roadmap feature. That would allow sharing without requiring a github accounts /grantin zenhub permissions. As of now, it only allows a image export, but they seem to do some more work there: https://portal.productboard.com/zenhub/1-zenhub-portal/c/90-sharing-make-roadmap-public