### PR TITLE
Replace FARMRanker with SentenceTransformersRanker in pipeline

### DIFF
--- a/docs/latest/components/pipelines.mdx
+++ b/docs/latest/components/pipelines.mdx
@@ -336,12 +336,12 @@ To create new pipeline nodes, we initialize the modules first. For our use case,
 
 ``` python
 from haystack.retriever import ElasticsearchRetriever
-from haystack.ranker import FARMRanker
+from haystack.ranker import SentenceTransformersRanker
 from haystack.summarizer import TransformersSummarizer
 
 retriever = ElasticsearchRetriever(document_store, top_k=10)
 
-ranker=FARMRanker(model_name_or_path="sentence-transformers/distilbert-multilingual-nli-stsb-quora-ranking", top_k=10)
+ranker = SentenceTransformersRanker(model_name_or_path="cross-encoder/ms-marco-MiniLM-L-12-v2", top_k=10)
 
 summarizer = TransformersSummarizer(model_name_or_path='t5-large', min_length=10, max_length=300, generate_single_summary=True)
 ```


### PR DESCRIPTION
The pipeline example still used FARMRanker, which we removed with the FARM migration PR. https://github.com/deepset-ai/haystack/pull/1492
This PR now uses SentenceTransformersRanker instead.