### PR TITLE
Add documentation about the new 'delete_by_filters' REST endpoint

### DIFF
--- a/docs/latest/guides/rest_api.mdx
+++ b/docs/latest/guides/rest_api.mdx
@@ -87,6 +87,11 @@ This endpoint returns JSON output in the SQuAD format for question/answer pairs 
 
 You can use this endpoint to upload a file for indexing (see the section below for more details on indexing).
 
+
+#### POST ​/documents/delete_by_filters
+
+This endpoint allows you to delete a subset of the documents contained in your document store. You can filter the documents to delete by metadata (like the document's name), or provide an empty JSON object to clear the document store.
+
 ### Running HTTP API without Docker
 
 If you prefer to not use Docker with your Haystack API, you can start the REST API server and supporting Haystack pipeline by running the gunicorn server manually with the following command:


### PR DESCRIPTION
Related to https://github.com/deepset-ai/haystack/pull/1546 

-------------------------

Add a short line of documentation about the new `POST /documents/delete_by_filters` REST API endpoint