### PR TITLE
Fix incorrect link in preprocessing docs

### DIFF
--- a/docs/latest/components/preprocessing.mdx
+++ b/docs/latest/components/preprocessing.mdx
@@ -12,7 +12,7 @@ and effective handling of data is key to getting the most out of Haystack.
 
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme px-6 pt-6 pb-4 my-4 rounded-md dark:bg-yellow-900">
 
-Check out our [preprocessing tutorial](/tutorials/train-dpr) if you'd like to start working with code examples already!
+Check out our [preprocessing tutorial](/tutorials/preprocessing) if you'd like to start working with code examples already!
 
 </div>
 


### PR DESCRIPTION
Link pointed to DPR training page rather than preprocessing tutorial