### PR TITLE
InMemoryDocumentStore can now work with dense retrievers.

### DIFF
--- a/docs/latest/components/document_store.mdx
+++ b/docs/latest/components/document_store.mdx
@@ -322,11 +322,12 @@ The Document Stores have different characteristics. You should choose one depend
                 <strong>Pros:</strong>
                 <ul>
                     <li>Simple</li>
-                    <li>Exists already in many environments</li>
+                    <li>No extra services or dependencies</li>
                 </ul>
                 <strong>Cons:</strong>
                 <ul>
-                    <li>Bad retrieval performance</li>
+                    <li>Slow retrieval on larger datasets</li>
+                    <li>No Approximate Nearest Neighbours (ANN)</li>
                     <li>Not recommended for production</li>
                 </ul>
                 </div>

--- a/docs/latest/components/document_store.mdx
+++ b/docs/latest/components/document_store.mdx
@@ -326,7 +326,6 @@ The Document Stores have different characteristics. You should choose one depend
                 </ul>
                 <strong>Cons:</strong>
                 <ul>
-                    <li>Only compatible with minimal TF-IDF Retriever</li>
                     <li>Bad retrieval performance</li>
                     <li>Not recommended for production</li>
                 </ul>


### PR DESCRIPTION
The documentation says InMemoryDocumentStore can only work with tdf-idf yet it currently implements query_by_embedding which means it can work with dense retrievers now. Therefore the documentation is outdated. It was implemented almost 2 years ago: https://github.com/deepset-ai/haystack/commit/bf8e506c45a9c7084e5f122d0ada706ac070e1e3