### PR TITLE
Fix typos in get_started.mdx

### DIFF
--- a/docs/latest/overview/get_started.mdx
+++ b/docs/latest/overview/get_started.mdx
@@ -148,7 +148,7 @@ This splitting can have a big impact on speed and performance.
   an improvement to performance, you might want to try concatenating text to
   make larger Documents. 
   
-  See [Optimization](/guides/optimization) for more details.
+  See [Optimization](https://haystack.deepset.ai/guides/optimization) for more details.
 
 </div>
 

--- a/docs/latest/overview/get_started.mdx
+++ b/docs/latest/overview/get_started.mdx
@@ -142,7 +142,8 @@ You might want to use all the text in one file as a Document, or split it into m
 This splitting can have a big impact on speed and performance.
 
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme p-6 my-4 rounded-md dark:bg-yellow-900">
-  <span className="font-bold">Tip:</span> If Haystack is running very slowly,
+  
+  **Tip:** If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
   make larger Documents. 

--- a/docs/latest/overview/get_started.mdx
+++ b/docs/latest/overview/get_started.mdx
@@ -197,7 +197,7 @@ When the query is complete, you can expect to see results that look something li
 
 ## Custom Search Pipelines
 
-Haystack provider many different building blocks for you to mix and match.
+Haystack provides many different building blocks for you to mix and match.
 They include:
 
 - Readers

--- a/docs/latest/overview/get_started.mdx
+++ b/docs/latest/overview/get_started.mdx
@@ -140,15 +140,14 @@ document_store.write_documents(dicts)
 When we talk about Documents in Haystack, we are referring specifically to the individual blocks of text that are being held in the DocumentStore.
 You might want to use all the text in one file as a Document, or split it into multiple Documents.
 This splitting can have a big impact on speed and performance.
-
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme p-6 my-4 rounded-md dark:bg-yellow-900">
   
-  **Tip:** If Haystack is running very slowly,
+  <b>Tip:</b> If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
   make larger Documents. 
   
-  See [Optimization](https://haystack.deepset.ai/guides/optimization) for more details.
+  See <a href="https://haystack.deepset.ai/guides/optimization">Optimization</a> for more details.
 
 </div>
 

--- a/docs/latest/overview/get_started.mdx
+++ b/docs/latest/overview/get_started.mdx
@@ -145,10 +145,10 @@ This splitting can have a big impact on speed and performance.
   <span className="font-bold">Tip:</span> If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
-  make larger Documents. See [Optimization](/guides/optimization) for
-  more details.
+  make larger Documents. 
+  
+  See [Optimization](/guides/optimization) for more details.
 </div>
-
 <div style={{ marginBottom: "3rem" }} />
 
 ## Running Search Queries
@@ -197,7 +197,7 @@ When the query is complete, you can expect to see results that look something li
 
 ## Custom Search Pipelines
 
-Haystack providers many different building blocks for you to mix and match.
+Haystack provider many different building blocks for you to mix and match.
 They include:
 
 - Readers
@@ -207,5 +207,5 @@ They include:
 - Generators
 - Translators
 
-These can all be combined in the configuration that you want.
+These can all be combined in a configuration that you want.
 Have a look at our [Pipelines page](/components/pipelines) to see what's possible!

--- a/docs/latest/overview/get_started.mdx
+++ b/docs/latest/overview/get_started.mdx
@@ -148,7 +148,9 @@ This splitting can have a big impact on speed and performance.
   make larger Documents. 
   
   See [Optimization](/guides/optimization) for more details.
+
 </div>
+
 <div style={{ marginBottom: "3rem" }} />
 
 ## Running Search Queries


### PR DESCRIPTION
Fixed another typo in tutorial and a link not rendering in between `<div>`