### PR TITLE
Create standalone installation page

### DIFF
--- a/docs/latest/menu.json
+++ b/docs/latest/menu.json
@@ -5,10 +5,11 @@
     "items": [
       { "slug": "intro", "title": "What is Haystack?" },
       {"slug": "get-started", "title": "Get Started"},
-      {"slug": "use-cases", "title": "Use Cases" },
+      {"slug": "installation", "title": "Installation" },
       {"slug": "quick-demo", "title": "Quick Demo"},
       {"slug": "migration", "title": "Migration to v1.0" },
       {"slug": "roadmap", "title": "Roadmap" },
+      {"slug": "use-cases", "title": "Use Cases" },
       {"slug": "faq", "title": "FAQ" },
       {"slug": "glossary", "title": "Glossary" }
     ]

--- a/docs/latest/overview/get_started.mdx
+++ b/docs/latest/overview/get_started.mdx
@@ -1,15 +1,17 @@
 # Get Started
 
-## Installation
+<div style={{ marginBottom: "3rem" }} />
 
 <Tabs
   options={[
     {
-      title: "Basic",
+      title: "Basic Install",
       content: (
         <div>
           <p>
-            The most straightforward way to install Haystack is through pip.
+              The most straightforward way to install the latest release of Haystack is through pip.
+              This command will install everything needed for Pipelines that use an Elasticsearch Document Store.
+              See <a href="https://haystack.deepset.ai/overview/installation">Installation</a> for more details.
           </p>
           <pre>
             <code>pip install farm-haystack</code>
@@ -18,34 +20,40 @@
       ),
     },
     {
-      title: "Editable",
+      title: "Full Install",
       content: (
         <div>
           <p>
-            If you’d like to run a specific, unreleased version of Haystack, or
-            make edits to the way Haystack runs, you’ll want to install it using
-            `git` and `pip --editable`. This clones a copy of the repo to a
-            local directory and runs Haystack from there.
+              If you plan to be using more advanced features like Milvus, FAISS, Weaviate, OCR or Ray, you will need to install a full version of Haystack.
+              The following command will install the latest version on the master branch.
+              See <a href="https://haystack.deepset.ai/overview/installation">Installation</a> for more details.
           </p>
           <pre>
             <code>git clone https://github.com/deepset-ai/haystack.git</code>
             <code>cd haystack</code>
-            <code>pip install --editable .</code>
+            <code>pip install -e .[all]</code>
           </pre>
+        </div>
+      ),
+    },
+      {
+      title: "Online Demo",
+      content: (
+        <div>
           <p>
-            By default, this will give you the latest version of the master
-            branch. Use regular git commands to switch between different
-            branches and commits.
+              See what Haystack can do with our <a href="https://haystack-demo.deepset.ai/">Explore the World demo</a>!
           </p>
         </div>
       ),
     },
         {
-      title: "Docker",
+      title: "Local Demo",
       content: (
         <div>
           <p>
-            Run a demo via Docker.
+            You can set up and run a local Haystack demo via Docker.
+            To enable GPU acceleration, add the `-f docker-compose-gpu.yml` flag to both `docker-compose` commands.
+            See <a href="https://haystack.deepset.ai/overview/quick-demo#local">Quick Demo</a> for more details.
           </p>
           <pre>
             <code>git clone https://github.com/deepset-ai/haystack.git</code>
@@ -56,34 +64,12 @@
         </div>
       ),
     },
-            {
-      title: "Docker (GPU)",
-      content: (
-        <div>
-          <p>
-            Run a demo via Docker using GPUs.
-          </p>
-          <pre>
-            <code>git clone https://github.com/deepset-ai/haystack.git</code>
-            <code>cd haystack</code>
-            <code>docker-compose -f docker-compose-gpu.yml pull</code>
-            <code>docker-compose -f docker-compose-gpu.yml up</code>
-            </pre>
-        </div>
-      ),
-    },
   ]}
 />
 
-<div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme px-6 pt-6 pb-4 my-4 rounded-md dark:bg-yellow-900">
+## Installation
 
-**Windows:** On Windows add the arg `-f https://download.pytorch.org/whl/torch_stable.html` to install PyTorch correctly
-
-**Apple M1 (a.k.a. Apple Silicon):** Please check out [this thread](https://github.com/deepset-ai/haystack/issues/1310#issuecomment-996824097) for a guide on installation
-
-</div>
-
-<div style={{ marginBottom: "3rem" }} />
+For a full guide on how to install Haystack see [Installation](/overview/installation).
 
 ## Quick Demo
 

--- a/docs/latest/overview/installation.mdx
+++ b/docs/latest/overview/installation.mdx
@@ -1,0 +1,19 @@
+# Installation
+
+Basic Installation
+latest release
+
+Full Installation
+editable
+lateset master
+
+Custom Installation
+config file
+pip issue
+
+rest api
+
+UI
+
+Change link in readme
+Readme on REST API and UI?

--- a/docs/latest/overview/installation.mdx
+++ b/docs/latest/overview/installation.mdx
@@ -1,19 +1,85 @@
 # Installation
 
-Basic Installation
-latest release
+## Basic Installation
 
-Full Installation
-editable
-lateset master
+You can install a basic version of Haystack's latest release by using [pip](https://github.com/pypa/pip).
 
-Custom Installation
-config file
-pip issue
+```
+    pip install farm-haystack
+```
 
-rest api
+This command will install everything needed for basic Pipelines that use an Elasticsearch Document Store.
 
-UI
+## Full Installation
 
-Change link in readme
-Readme on REST API and UI?
+If you plan to be using more advanced features like Milvus, FAISS, Weaviate, OCR or Ray,
+you will need to install a full version of Haystack.
+The following command will install the latest version of Haystack from the master branch.
+
+```
+git clone https://github.com/deepset-ai/haystack.git
+cd haystack
+pip install --upgrade pip
+pip install -e .[all] ## or 'all-gpu' for the GPU-enabled dependencies
+```
+
+The `-e` flag makes this an editable installation meaning that changes to the cloned repo will affect how the package runs.
+You can call `git pull` on the repo to update.
+
+If the `install` command does not work for you and you have `pip<21.3`, see [Custom Installation](/overview/installation#custom-installation)
+
+## REST API and UI
+
+Run the following from the root directory of the Haystack repo
+
+```
+pip install rest_api/
+pip install ui/
+```
+
+## Installing on Windows
+
+```
+pip install farm-haystack -f https://download.pytorch.org/whl/torch_stable.html
+```
+
+## Installing on Apple Silicon (M1)
+
+M1 Macbooks require some extra depencies in order to install Haystack.
+
+```
+# some additional dependencies needed on m1 mac
+brew install postgresql
+brew install cmake
+brew install rust
+
+# haystack installation
+GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip install git+https://github.com/deepset-ai/haystack.git
+```
+
+## Custom Installation
+
+The dependencies of Haystack are split into different groupings.
+You can find these in `haystack/setup.cfg`.
+
+To install groups of dependencies along with Haystack, specify them in the `pip install` command.
+
+```
+pip install -e .[all]            # install haystack and all depedencies
+pip install -e .[all-gpu]        # install haystack, all dependencies and gpu support
+pip install -e .[docstores-gpu]  # install haystack, all docstores and gpu support
+pip install -e .[docstores-gpu]  # install haystack, all docstores and gpu support
+
+```
+
+If you are running `pip<21.3` you won't be able to install dependency groups that reference other groups.
+Instead you can only specify groups that contain direct package references.
+
+```
+# instead of [all]
+pip install -e .[sql,only-faiss,only-milvus1,weaviate,graphdb,crawler,preprocessing,ocr,onnx,ray,dev]
+
+# instead of [all-gpu]
+pip install -e .[sql,only-faiss-gpu,only-milvus1,weaviate,graphdb,crawler,preprocessing,ocr,onnx-gpu,ray,dev]
+```
+

--- a/docs/latest/overview/installation.mdx
+++ b/docs/latest/overview/installation.mdx
@@ -54,15 +54,13 @@ brew install cmake
 brew install rust
 
 # haystack installation
-GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip install git+https://github.com/deepset-ai/haystack.git
+GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip install farm-haystack
 ```
 
 ## Custom Installation
 
-The dependencies of Haystack are split into different groupings.
-You can find these in `haystack/setup.cfg`.
-
 To install groups of dependencies along with Haystack, specify them in the `pip install` command.
+The dependencies of Haystack are split into different groupings which you can find in `haystack/setup.cfg`.
 
 ```
 pip install -e .[all]            # install haystack and all depedencies

--- a/docs/latest/overview/installation.mdx
+++ b/docs/latest/overview/installation.mdx
@@ -28,24 +28,28 @@ You can call `git pull` on the repo to update.
 
 If the `install` command does not work for you and you have `pip<21.3`, see [Custom Installation](/overview/installation#custom-installation)
 
-## REST API and UI
+## Installing the REST API and UI
 
-Run the following from the root directory of the Haystack repo
+Haystack comes packaged with a REST API so that it can be deployed as a service.
+There is also a UI that interacts with this service to provide an interactive app to the user.
+To install these, run the following from the root directory of the Haystack repo.
 
 ```
 pip install rest_api/
 pip install ui/
 ```
 
-## Installing on Windows
+## Other Operating Systems
+
+### Windows
 
 ```
 pip install farm-haystack -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
-## Installing on Apple Silicon (M1)
+### Apple Silicon (M1)
 
-M1 Macbooks require some extra depencies in order to install Haystack.
+Macs with a M1 processor require some extra dependencies in order to install Haystack.
 
 ```
 # some additional dependencies needed on m1 mac
@@ -59,15 +63,21 @@ GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip install farm-haystack
 
 ## Custom Installation
 
-To install groups of dependencies along with Haystack, specify them in the `pip install` command.
+To install groups of optional dependencies along with Haystack, specify them in the `pip install` command.
 The dependencies of Haystack are split into different groupings which you can find in `haystack/setup.cfg`.
 
 ```
-pip install -e .[all]            # install haystack and all depedencies
-pip install -e .[all-gpu]        # install haystack, all dependencies and gpu support
-pip install -e .[docstores-gpu]  # install haystack, all docstores and gpu support
-pip install -e .[docstores-gpu]  # install haystack, all docstores and gpu support
+# install haystack and all optional depedencies
+pip install -e .[all]
 
+# install haystack and all optional dependencies with gpu support
+pip install -e .[all-gpu]
+
+# install haystack and all docstores with gpu support
+pip install -e .[docstores-gpu]
+
+# install haystack and faiss with gpu support
+pip install -e .[faiss-gpu]
 ```
 
 If you are running `pip<21.3` you won't be able to install dependency groups that reference other groups.

--- a/docs/latest/overview/installation.mdx
+++ b/docs/latest/overview/installation.mdx
@@ -5,7 +5,7 @@
 You can install a basic version of Haystack's latest release by using [pip](https://github.com/pypa/pip).
 
 ```
-    pip install farm-haystack
+pip install farm-haystack
 ```
 
 This command will install everything needed for basic Pipelines that use an Elasticsearch Document Store.


### PR DESCRIPTION
Since we have a new dependency management system in Haystack, there are now many more options for installation. 

This PR creates a dedicated `installation` page and also refactors the `get started` page. 

Note that after this PR is merged, there is a link in the Haystack readme that needs to be updated.