### PR TITLE
change old "text" to "content" for translator examples

### DIFF
--- a/docs/latest/components/translator.mdx
+++ b/docs/latest/components/translator.mdx
@@ -20,7 +20,7 @@ from haystack.nodes import TransformersTranslator
 
 DOCS = [
         Document(
-            text="""Heinz von Foerster was an Austrian American scientist
+            content="""Heinz von Foerster was an Austrian American scientist
                   combining physics and philosophy, and widely attributed
                   as the originator of Second-order cybernetics."""
         )

--- a/docs/v1.0.0/components/translator.mdx
+++ b/docs/v1.0.0/components/translator.mdx
@@ -20,7 +20,7 @@ from haystack.nodes import TransformersTranslator
 
 DOCS = [
         Document(
-            text="""Heinz von Foerster was an Austrian American scientist
+            content="""Heinz von Foerster was an Austrian American scientist
                   combining physics and philosophy, and widely attributed
                   as the originator of Second-order cybernetics."""
         )

--- a/docs/v1.1.0/components/translator.mdx
+++ b/docs/v1.1.0/components/translator.mdx
@@ -20,7 +20,7 @@ from haystack.nodes import TransformersTranslator
 
 DOCS = [
         Document(
-            text="""Heinz von Foerster was an Austrian American scientist
+            content="""Heinz von Foerster was an Austrian American scientist
                   combining physics and philosophy, and widely attributed
                   as the originator of Second-order cybernetics."""
         )


### PR DESCRIPTION
## Proposed changes: ##
The example snippets of the translator include the argument "text", though it should be "content"