### PR TITLE
fix link and remove from v0.9.0

### DIFF
--- a/docs/v0.10.0/overview/get_started.mdx
+++ b/docs/v0.10.0/overview/get_started.mdx
@@ -138,13 +138,13 @@ document_store.write_documents(dicts)
 When we talk about Documents in Haystack, we are referring specifically to the individual blocks of text that are being held in the DocumentStore.
 You might want to use all the text in one file as a Document, or split it into multiple Documents.
 This splitting can have a big impact on speed and performance.
-
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme p-6 my-4 rounded-md dark:bg-yellow-900">
-  <span className="font-bold">Tip:</span> If Haystack is running very slowly,
+
+  <b>Tip:</b> If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
-  make larger Documents. See [Optimization](/guides/v0.10.0/optimization) for
-  more details.
+  make larger Documents. 
+
 </div>
 
 <div style={{ marginBottom: "3rem" }} />

--- a/docs/v0.9.0/overview/get_started.mdx
+++ b/docs/v0.9.0/overview/get_started.mdx
@@ -96,13 +96,13 @@ document_store.write_documents(dicts)
 When we talk about Documents in Haystack, we are referring specifically to the individual blocks of text that are being held in the DocumentStore.
 You might want to use all the text in one file as a Document, or split it into multiple Documents.
 This splitting can have a big impact on speed and performance.
-
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme p-6 my-4 rounded-md dark:bg-yellow-900">
-  <span className="font-bold">Tip:</span> If Haystack is running very slowly,
+
+  <b>Tip:</b> If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
-  make larger Documents. See [Optimization](/guides/v0.9.0/optimization) for
-  more details.
+  make larger Documents. 
+
 </div>
 
 <div style={{ marginBottom: "3rem" }} />

--- a/docs/v1.0.0/overview/get_started.mdx
+++ b/docs/v1.0.0/overview/get_started.mdx
@@ -146,7 +146,7 @@ This splitting can have a big impact on speed and performance.
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
   make larger Documents. 
-
+  
   See <a href="https://haystack.deepset.ai/guides/v1.0.0/optimization">Optimization</a> for more details.
 
 </div>

--- a/docs/v1.0.0/overview/get_started.mdx
+++ b/docs/v1.0.0/overview/get_started.mdx
@@ -140,13 +140,15 @@ document_store.write_documents(dicts)
 When we talk about Documents in Haystack, we are referring specifically to the individual blocks of text that are being held in the DocumentStore.
 You might want to use all the text in one file as a Document, or split it into multiple Documents.
 This splitting can have a big impact on speed and performance.
-
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme p-6 my-4 rounded-md dark:bg-yellow-900">
-  <span className="font-bold">Tip:</span> If Haystack is running very slowly,
+
+  <b>Tip:</b> If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
-  make larger Documents. See [Optimization](/guides/v1.0.0/optimization) for
-  more details.
+  make larger Documents. 
+
+  See <a href="https://haystack.deepset.ai/guides/v1.0.0/optimization">Optimization</a> for more details.
+
 </div>
 
 <div style={{ marginBottom: "3rem" }} />

--- a/docs/v1.1.0/overview/get_started.mdx
+++ b/docs/v1.1.0/overview/get_started.mdx
@@ -140,13 +140,15 @@ document_store.write_documents(dicts)
 When we talk about Documents in Haystack, we are referring specifically to the individual blocks of text that are being held in the DocumentStore.
 You might want to use all the text in one file as a Document, or split it into multiple Documents.
 This splitting can have a big impact on speed and performance.
-
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme p-6 my-4 rounded-md dark:bg-yellow-900">
-  <span className="font-bold">Tip:</span> If Haystack is running very slowly,
+
+  <b>Tip:</b> If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
-  make larger Documents. See [Optimization](/guides/v1.1.0/optimization) for
-  more details.
+  make larger Documents. 
+
+  See <a href="https://haystack.deepset.ai/guides/v1.1.0/optimization">Optimization</a> for more details.
+
 </div>
 
 <div style={{ marginBottom: "3rem" }} />

--- a/docs/v1.1.0/overview/get_started.mdx
+++ b/docs/v1.1.0/overview/get_started.mdx
@@ -146,7 +146,7 @@ This splitting can have a big impact on speed and performance.
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
   make larger Documents. 
-
+  
   See <a href="https://haystack.deepset.ai/guides/v1.1.0/optimization">Optimization</a> for more details.
 
 </div>

--- a/docs/v1.2.0/overview/get_started.mdx
+++ b/docs/v1.2.0/overview/get_started.mdx
@@ -126,13 +126,15 @@ document_store.write_documents(dicts)
 When we talk about Documents in Haystack, we are referring specifically to the individual blocks of text that are being held in the DocumentStore.
 You might want to use all the text in one file as a Document, or split it into multiple Documents.
 This splitting can have a big impact on speed and performance.
-
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme p-6 my-4 rounded-md dark:bg-yellow-900">
-  <span className="font-bold">Tip:</span> If Haystack is running very slowly,
+
+  <b>Tip:</b> If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
-  make larger Documents. See [Optimization](/guides/v1.2.0/optimization) for
-  more details.
+  make larger Documents. 
+
+  See <a href="https://haystack.deepset.ai/guides/v1.2.0/optimization">Optimization</a> for more details.
+
 </div>
 
 <div style={{ marginBottom: "3rem" }} />

--- a/docs/v1.2.0/overview/get_started.mdx
+++ b/docs/v1.2.0/overview/get_started.mdx
@@ -132,7 +132,7 @@ This splitting can have a big impact on speed and performance.
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
   make larger Documents. 
-
+  
   See <a href="https://haystack.deepset.ai/guides/v1.2.0/optimization">Optimization</a> for more details.
 
 </div>

--- a/docs/v1.3.0/overview/get_started.mdx
+++ b/docs/v1.3.0/overview/get_started.mdx
@@ -126,13 +126,15 @@ document_store.write_documents(dicts)
 When we talk about Documents in Haystack, we are referring specifically to the individual blocks of text that are being held in the DocumentStore.
 You might want to use all the text in one file as a Document, or split it into multiple Documents.
 This splitting can have a big impact on speed and performance.
-
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme p-6 my-4 rounded-md dark:bg-yellow-900">
-  <span className="font-bold">Tip:</span> If Haystack is running very slowly,
+
+  <b>Tip:</b> If Haystack is running very slowly,
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
-  make larger Documents. See [Optimization](/guides/v1.3.0/optimization) for
-  more details.
+  make larger Documents. 
+
+  See <a href="https://haystack.deepset.ai/guides/v1.3.0/optimization">Optimization</a> for more details.
+
 </div>
 
 <div style={{ marginBottom: "3rem" }} />

--- a/docs/v1.3.0/overview/get_started.mdx
+++ b/docs/v1.3.0/overview/get_started.mdx
@@ -132,7 +132,7 @@ This splitting can have a big impact on speed and performance.
   you might want to try splitting your text into smaller Documents. If you want
   an improvement to performance, you might want to try concatenating text to
   make larger Documents. 
-
+  
   See <a href="https://haystack.deepset.ai/guides/v1.3.0/optimization">Optimization</a> for more details.
 
 </div>


### PR DESCRIPTION
Following the changes already made in https://github.com/deepset-ai/haystack-website/pull/241 this PR fixes the link to the optimization guide on the get_started.mdx page For all versions v1.3.0 to v1.0.0. 

In addition, for v0.9.0, the link pointed to a non-existent page so the link was removed completely.