### PR TITLE
Use the locally cloned repo instead of calling GitHub API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,32 @@
 
 ### Getting Started
 
-First, install Next.js (if needed):
-
+First, install the dependencies (If you are running into issues with this,
+make sure to update Node to the latest version):
 ```bash
-npm install next react react-dom
-# or
-yarn install next 
+yarn install
 ```
 
-If you are running into issues with this, make sure to update Node to the latest version.
-
-Then, run the development server:
-
+Part of the documentation source lives within the [Haystack repo](https://github.com/deepset-ai/haystack)
+and the build system expects to find it locally, so before running the development
+server run this command to get a local copy of Haystack:
 ```bash
-npm run dev
-# or
+yarn haystack
+```
+
+At this point you can run the development server:
+```bash
 yarn dev
 ```
 
-If you're editing mdx files, run the following command to see your changes update automatically:
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+When editing `.mdx` files, you can run the following command to see your changes update automatically:
 ```bash
-npm run dev:watch
-# or
 yarn dev:watch
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-Note: This setup is tested with node v14.17.5 - but might be incompatible to older/newer versions. 
+Note: This setup is tested with node v14.17.5 - but might be incompatible to older/newer versions.
 
 #### Environment Variables
 
@@ -53,16 +51,21 @@ These docs live in the `docs` directory, in the given version directory. The doc
 
 ### Tutorial & Reference Docs
 
-These docs live in the [Haystack repository](https://github.com/deepset-ai/haystack/tree/master/docs), in the given version directory. The docs are generated markdown files and we fetch these **at build time** using the GitHub API. Thanks to Vercel's [Incremental Static Regeneration](https://vercel.com/docs/next.js/incremental-static-regeneration), the static pages we create for these docs are always up-to-date. This means that if existing tutorials or references are changed, the changes will be visible on the docs website automatically.
+These docs live in the [Haystack repository](https://github.com/deepset-ai/haystack/tree/master/docs),
+in the given version directory. The docs are generated markdown files and must be fetched before the
+build starts. Thanks to Vercel's [Incremental Static Regeneration](https://vercel.com/docs/next.js/incremental-static-regeneration), the static pages we create for these docs are always up-to-date. This
+means that if existing tutorials or references are changed, the changes will be visible on the docs
+website automatically.
 
 ### Adding a new Tutorial Page
 
 In the Haystack repo, add an entry into `haystack/docs/_src/tutorials/tutorials/headers.py` that corresponds to your new tutorial. When you push your changes to any branch, there is a Github action that calls `haystack/docs/_src/tutorials/tutorials/convert_ipynb.py` to generate a `.md` version of the tutorial in the same folder. These `.md` files are generally called something like `12.md`.
 
-Then in this Haystack Website repo, you need to add an entry to `haystack-website/lib/constants.ts` to refer to the new `.md` file in Haystack. Please add the new file only to the latest version. If you remove files, you also have to remove it in the latest version. To make it appear in the left Table of Contents, you need to add a new entry to `haystack-website/docs/latest/menu.json`. 
+Then in this repo, you need to add an entry to `haystack-website/lib/constants.ts` to refer to the new `.md` file in Haystack. Please add the new file only to the latest version. If you remove files, you also
+have to remove it in the latest version. To make it appear in the left Table of Contents, you need to
+add a new entry to `haystack-website/docs/latest/menu.json`.
 
 For example:
-
 ```
 const res = await octokit.rest.repos.getContent({
   owner: "deepset-ai",
@@ -71,15 +74,13 @@ const res = await octokit.rest.repos.getContent({
   ref: HAYSTACK_BRANCH_NAME
 });
 ```
-
-
 ### Preview from non-master branches
 
 To preview docs that are on a non-master branch of the Haystack repo, you run this project locally and navigate to `lib/github.ts`, where you have to add a `ref` parameter to the `octokit.rest.repos.getContent` function call with the value of the branch name that you would like to preview. You also need to add the tutorials/references you would like to preview to `docs/{GIVEN_VERSION}/menu.json` and `lib/constants.ts`.
 
 ### Redirects In Case of Renaming or Restructuring Pages
 
-When renaming documentation pages, or restructuring the directories that they're contained in, the new filepath can cause old links to break. For example, when the pipeline_nodes grouping was created `components/reader.mdx` did not exist any more as it had changed to `pipeline_nodes/reader.mdx`. This meant that links on websites were broken. 
+When renaming documentation pages, or restructuring the directories that they're contained in, the new filepath can cause old links to break. For example, when the pipeline_nodes grouping was created `components/reader.mdx` did not exist any more as it had changed to `pipeline_nodes/reader.mdx`. This meant that links on websites were broken.
 
 To make sure links aren't broken please follow these steps:
 
@@ -93,19 +94,19 @@ To make sure links aren't broken please follow these steps:
       permanent: true,
     }
     ```
-    
+
    The `haystack-website/docs/generate_redirect_table.py` script will generate a set of suggested mappings. In cases where the directory structure has changed but the filename has stayed the same, this script will map from the old link to the new link in latest. In cases where the filename has changed, this script will identify the old link but not provide a suggestion for a new link. Update the `MANUAL_REDIRECTS` option to define any custom destinations.
 
-3. Push the changes to your branch and test that the old paths still work and point to the intended destination. You can do this by checking out the 
+3. Push the changes to your branch and test that the old paths still work and point to the intended destination. You can do this by checking out the
 Preview that Vercel will produce.
 
 ### Updating docs after a release
 
-When there's a new Haystack release, we need to create a directory for the new version within the local `/docs` directory. In this directory, we can write new overview and usage docs in .mdx (or manually copy over the ones from the previous version directory). Once this is done, the project will automatically fetch the reference and tutorial docs for the new version from GitHub. Bear in mind that a `menu.json` file needs to exist in every new version directory so that our Menu components know which page links to display. 
+When there's a new Haystack release, we need to create a directory for the new version within the local `/docs` directory. In this directory, we can write new overview and usage docs in .mdx (or manually copy over the ones from the previous version directory). Once this is done, the project will automatically fetch the reference and tutorial docs for the new version from GitHub. Bear in mind that a `menu.json` file needs to exist in every new version directory so that our Menu components know which page links to display.
 
 Moreover, we need to point the links, which are pointing to the latest version, to the new version. Update links in docs using `haystack-website/docs/update_links.py`. The command you run should look something like `python update_links.py -d v0.3.0 -v v0.3.0`. This script prints the changes to console. Have a scan through these as a sanity check.
 
-Additionally, the `referenceFiles` and `tutorialFiles` constants in `lib/constants` need to be updated with any new reference or tutorial docs that get created as part of a new release. During a release, please add a new object `referenceFiles` and `tutorialFiles` with the release number to file. This change has also implications on the files `tutorials/[...slug].tsx` and `reference/[...slug].tsx`. Please update the functions `getStaticPaths` and `getStaticProps` in both files with an array representing the latest version. 
+Additionally, the `referenceFiles` and `tutorialFiles` constants in `lib/constants` need to be updated with any new reference or tutorial docs that get created as part of a new release. During a release, please add a new object `referenceFiles` and `tutorialFiles` with the release number to file. This change has also implications on the files `tutorials/[...slug].tsx` and `reference/[...slug].tsx`. Please update the functions `getStaticPaths` and `getStaticProps` in both files with an array representing the latest version.
 
 In the [haystack](https://github.com/deepset-ai/haystack) repo, we have to release the api and tutorial docs by copying them to a new version folder as well. If you want to include here files from another branch than master follow **Preview from non-master branches**. **Lastly**, we have to update the constant specified in the `components/VersionSelect` component, so that we default to the new version when navigating between pages.
 
@@ -119,8 +120,13 @@ We use [Tailwind](https://tailwindcss.com) for CSS. It's a CSS utility library, 
 
 ## Deployment
 
-This application gets deployed on [Vercel](https://vercel.com). In the dashboard, connect the `haystack-website` repo to a new project and it should handle builds, preview environments (all branches other than master), and production environments (master branch) automatically.
+This application gets deployed on [Vercel](https://vercel.com). In the dashboard, connect the
+`haystack-website` repo to a new project and it should handle builds, preview environments (all branches
+other than master), and production environments (master branch) automatically. Be sure to include
+`yarn haystack` in the list of build commands.
 
 ## Future Work
 
-Convert the remote markdown files for references and tutorials to .mdx, so that we can inject React components into these. This would also allow for more code sharing between the overview+usage pages and tutorial+reference pages.
+Convert the remote markdown files for references and tutorials to .mdx, so that we can inject React
+components into these. This would also allow for more code sharing between the overview+usage pages and
+tutorial+reference pages.

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,31 +1,9 @@
+import fs from "fs";
 import { Octokit } from "octokit";
 
 export const octokit = new Octokit({
   auth: process.env.GITHUB_PERSONAL_ACCESS_TOKEN,
 });
-
-export const getDownloadUrl = async ({
-  filename,
-  repoPath,
-  version,
-}: {
-  filename: string;
-  repoPath: string;
-  version?: string;
-}) => {
-  try {
-    const res = await octokit.rest.repos.getContent({
-      owner: "deepset-ai",
-      repo: "haystack",
-      path: `docs${version && version !== "latest" ? `/${version}` : ""}${repoPath}${filename}`
-    });
-    if (Array.isArray(res.data)) return;
-    if (!res.data.download_url) return;
-    return res.data.download_url;
-  } catch (e) {
-    return;
-  }
-};
 
 export const getStargazersCount = async () => {
   const res = await octokit.rest.repos.get({
@@ -42,3 +20,21 @@ export const getHaystackReleaseTagNames = async () => {
   });
   return res.data.map((release) => release.tag_name);
 };
+
+export function getRawURL(path: string): string {
+  return `https://raw.githubusercontent.com/deepset-ai/haystack/master/docs/${path}`;
+}
+
+export function getRelativePath(
+  filename: string,
+  repoPath: string,
+  version: string
+): string {
+  const versionPrefix = version == "latest" ? "" : `/${version}`;
+  const relPath = `docs${versionPrefix}${repoPath}${filename}`;
+  if (!fs.existsSync(relPath)) {
+    return "";
+  }
+
+  return relPath;
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -21,10 +21,27 @@ export const getHaystackReleaseTagNames = async () => {
   return res.data.map((release) => release.tag_name);
 };
 
+/**
+ * This function is used during the markdown conversion process
+ * when an image stored in the Haystack repo has a relative URL
+ * that needs to be converted to absolute.
+ *
+ * @param path - the relative path to a file from the root of the repo
+ * @returns - the absolute path of a file in the Haystack repo
+ */
 export function getRawURL(path: string): string {
   return `https://raw.githubusercontent.com/deepset-ai/haystack/master/docs/${path}`;
 }
 
+/**
+ * Provided that the Haystack repo was cloned locally under `./haystack`, this
+ * function returns the filesystem path to a certain Haystack file
+ *
+ * @param filename - the name of the file
+ * @param repoPath - the path within the Haystack repo
+ * @param version - the version of the docs
+ * @returns - a path for a file relative to the local copy of Haystack
+ */
 export function getRelativePath(
   filename: string,
   repoPath: string,

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -31,7 +31,7 @@ export function getRelativePath(
   version: string
 ): string {
   const versionPrefix = version == "latest" ? "" : `/${version}`;
-  const relPath = `docs${versionPrefix}${repoPath}${filename}`;
+  const relPath = `haystack/docs${versionPrefix}${repoPath}${filename}`;
   if (!fs.existsSync(relPath)) {
     return "";
   }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,31 +1,31 @@
+import imgLinks from "@pondorasti/remark-img-links";
 import fs from "fs";
+import { MDXRemoteSerializeResult } from "next-mdx-remote";
 import { join } from "path";
 import remark from "remark";
-import html from "remark-html";
-import slug from "remark-slug";
-import remarkPrism from "remark-prism";
 import autolink from "remark-autolink-headings";
-import imgLinks from "@pondorasti/remark-img-links";
+import html from "remark-html";
+import remarkPrism from "remark-prism";
+import slug from "remark-slug";
 import { getHaystackReleaseTagNames, getStargazersCount } from "./github";
-import { MDXRemoteSerializeResult } from "next-mdx-remote";
 
 // we have to explicitly require prismjs and loadLanguages so that they're available during revalidation on Vercel
 const Prism = require("prismjs");
 const loadLanguages = require("prismjs/components/index");
-const slugger = require('github-slugger').slug;
+const slugger = require("github-slugger").slug;
 
 export const markdownToHtml = async ({
   content,
-  downloadUrl,
+  rawURL,
 }: {
   content: string;
-  downloadUrl: string;
+  rawURL: string;
 }) => {
   loadLanguages();
 
   const result = await remark()
     .use(imgLinks, {
-      absolutePath: downloadUrl,
+      absolutePath: rawURL,
     })
     // @ts-ignore
     .use(html)
@@ -97,7 +97,7 @@ export const getMenu = async (version?: string) => {
 
 export async function getDocsVersions() {
   const tagNames = await getHaystackReleaseTagNames();
-  tagNames.push('v1.0.0');
+  tagNames.push("v1.0.0");
   return tagNames.filter((tagName) => tagName.startsWith("v"));
 }
 
@@ -137,11 +137,16 @@ export async function getSlugsFromLocalMarkdownFiles(
   const directory = await getDirectory(category, version);
   if (!fs.existsSync(directory)) return [];
   const filenames = fs.readdirSync(directory);
-  return filenames.map((file) => file.replace(/\.mdx$/, "").split("_").join("-"));
+  return filenames.map((file) =>
+    file
+      .replace(/\.mdx$/, "")
+      .split("_")
+      .join("-")
+  );
 }
 
 export const getH1FromMarkdown = (md: string): string => {
   const matches = md.match(/# [a-zA-Z0-9 \-\"]+/);
-  if (matches?.length != 1) return '';
+  if (matches?.length != 1) return "";
   return matches[0].slice(2);
-}
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,7 +14,8 @@ const Prism = require("prismjs");
 const loadLanguages = require("prismjs/components/index");
 const slugger = require("github-slugger").slug;
 
-// variables to cache GitHub API results
+// To reduce the number of calls to the GitHub API, we store
+// the results in the following variables, acting as a cache.
 var tags: string[] = [];
 var stars: number = 0;
 
@@ -87,6 +88,7 @@ export const getStaticLayoutProps = async ({
     version || latestVersion
   }/${type}/${docTitleSlug.split("-").join("_")}.mdx`;
 
+  // Only hit the GitHub API the first time and cache the result
   if (stars == 0) {
     stars = await getStargazersCount();
   }
@@ -102,11 +104,13 @@ export const getMenu = async (version?: string) => {
 };
 
 export async function getDocsVersions() {
+  // Don't hit the GitHub API if we did it already
   if (tags.length > 0) {
     return tags;
   }
 
   const tagNames = await getHaystackReleaseTagNames();
+  // cache the results
   tags = tagNames.filter((tagName) => tagName.startsWith("v"));
   return tags;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,6 +14,10 @@ const Prism = require("prismjs");
 const loadLanguages = require("prismjs/components/index");
 const slugger = require("github-slugger").slug;
 
+// variables to cache GitHub API results
+var tags: string[] = [];
+var stars: number = 0;
+
 export const markdownToHtml = async ({
   content,
   rawURL,
@@ -83,7 +87,9 @@ export const getStaticLayoutProps = async ({
     version || latestVersion
   }/${type}/${docTitleSlug.split("-").join("_")}.mdx`;
 
-  const stars = await getStargazersCount();
+  if (stars == 0) {
+    stars = await getStargazersCount();
+  }
 
   return { menu, toc, editOnGitHubLink, stars, htmlTitle };
 };
@@ -96,9 +102,13 @@ export const getMenu = async (version?: string) => {
 };
 
 export async function getDocsVersions() {
+  if (tags.length > 0) {
+    return tags;
+  }
+
   const tagNames = await getHaystackReleaseTagNames();
-  tagNames.push("v1.0.0");
-  return tagNames.filter((tagName) => tagName.startsWith("v"));
+  tags = tagNames.filter((tagName) => tagName.startsWith("v"));
+  return tags;
 }
 
 export async function getVersionFromParams(params: string[]) {

--- a/pages/overview/[...slug].tsx
+++ b/pages/overview/[...slug].tsx
@@ -84,7 +84,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps<StaticPageProps> = async ({
   params,
 }: GetStaticPropsContext) => {
-  console.log()
   if (!params?.slug || !Array.isArray(params.slug)) {
     return {
       notFound: true,

--- a/pages/tutorials/[...slug].tsx
+++ b/pages/tutorials/[...slug].tsx
@@ -6,7 +6,7 @@ import {
 } from "next";
 import styles from "components/non-mdx.module.css";
 import Layout from "components/Layout";
-import { getDownloadUrl } from "lib/github";
+import { getRelativePath, getRawURL } from "lib/github";
 import {
   markdownToHtml,
   getVersionFromParams,
@@ -29,6 +29,7 @@ import { tutorialFilesV060 } from "lib/constants";
 import { tutorialFilesV050 } from "lib/constants";
 import { tutorialFilesV040 } from "lib/constants";
 import matter from "gray-matter";
+import fs from "fs";
 
 export default function TutorialDoc({
   menu,
@@ -268,22 +269,16 @@ export const getStaticProps: GetStaticProps<StaticPageProps> = async ({
         notFound: true,
       };
     }
+
     const version = await getVersionFromParams(params.slug);
-
-    const downloadUrl = await getDownloadUrl({
-      repoPath: tutorialFilesLatest.repoPath,
-      filename: item.filename,
-      version,
-    });
-
-    if (!downloadUrl) {
+    const filePath = getRelativePath(item.filename, tutorialFilesLatest.repoPath, version);
+    if (!filePath) {
       return {
         notFound: true,
       };
     }
-
-    const res = await fetch(downloadUrl);
-    const fileContent = await res.text();
+    const rawURL = getRawURL(filePath)
+    const fileContent = fs.readFileSync(filePath).toString();
 
     // remove once all markdown files have correctly formatted front matter:
     const fileContentWithFrontMatter = fileContent
@@ -291,7 +286,7 @@ export const getStaticProps: GetStaticProps<StaticPageProps> = async ({
       .replace("--->", "---");
 
     const { content } = matter(fileContentWithFrontMatter);
-    const { markup } = await markdownToHtml({ content, downloadUrl });
+    const { markup } = await markdownToHtml({ content, rawURL });
 
     const type = "";
 


### PR DESCRIPTION
After https://github.com/deepset-ai/haystack-website/pull/312 got merged, Vercel is calling `yarn haystack` as the first step of a build, which makes the Haystack files available locally under the `./haystack` folder, which made possible this PR.

This PR removes the `getDownloadUrl` method that was calling the Github API to retrieve the path to download Haystack files and adds two new functions `getRelativePath` and `getRawURL` that do the same using plain file operations on the local filesystem instead of querying an URL and download the file.

This change brings in several benefits:
- fixes https://github.com/deepset-ai/haystack-website/issues/289
- Cuts ~3 minutes from the build time
- It reduces the Github calls even further by caching the results of api calls that are still needed like `getHaystackReleaseTagNames()` and `getStargazersCount()`

Note: the diff is more complex than it could be because my editor reformatted some code, I think it's for the better but my apologies to the reviewers.