### PR TITLE
Add max height of 70vh to images in markdown document context

### DIFF
--- a/components/markdown.module.css
+++ b/components/markdown.module.css
@@ -53,6 +53,10 @@
   @apply mb-6;
 }
 
+.markdown img { 
+  max-height: 70vh;
+}
+
 .markdown ul {
   @apply list-disc list-inside;
 }

--- a/components/non-mdx.module.css
+++ b/components/non-mdx.module.css
@@ -13,6 +13,7 @@
 
 .nonMdx img {
   @apply mb-4;
+  max-height: 70vh;
 }
 
 .nonMdx code {


### PR DESCRIPTION
@agnieszka-m 
Implements #281 

As suggested lets use this branch to check whether this heuristic approach works.