### PR TITLE
Including the last 2 tutorials in latest and v1.4

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -183,6 +183,16 @@ export const tutorialFilesLatest: Meta = {
       filename: "14.md",
       title: 'Query Classifier',
     },
+    {
+      slug: "table-qa",
+      filename: "15.md",
+      title: 'Table Question Answering',
+    },
+    {
+      slug: "doc-class-index",
+      filename: "16.md",
+      title: 'Document Classification at Index',
+    },
   ],
 };
 
@@ -363,6 +373,16 @@ export const tutorialFilesV140: Meta = {
       slug: "query-classifier",
       filename: "14.md",
       title: 'Query Classifier',
+    },
+    {
+      slug: "table-qa",
+      filename: "15.md",
+      title: 'Table Question Answering',
+    },
+    {
+      slug: "doc-class-index",
+      filename: "16.md",
+      title: 'Document Classification at Index',
     },
   ],
 };

--- a/pages/reference/[...slug].tsx
+++ b/pages/reference/[...slug].tsx
@@ -304,8 +304,7 @@ export const getStaticProps: GetStaticProps<StaticPageProps> = async ({
       props: {
         ...layoutProps,
         source: markup,
-      },
-      revalidate: 60,
+      }
     };
   } catch (e) {
     console.log(e);

--- a/pages/reference/[...slug].tsx
+++ b/pages/reference/[...slug].tsx
@@ -186,7 +186,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: 'blocking',
+    fallback: true,
   };
 };
 
@@ -305,7 +305,7 @@ export const getStaticProps: GetStaticProps<StaticPageProps> = async ({
         ...layoutProps,
         source: markup,
       },
-      revalidate: 3600,
+      revalidate: 60,
     };
   } catch (e) {
     console.log(e);

--- a/pages/reference/[...slug].tsx
+++ b/pages/reference/[...slug].tsx
@@ -186,7 +186,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true,
+    fallback: false,
   };
 };
 

--- a/pages/reference/[...slug].tsx
+++ b/pages/reference/[...slug].tsx
@@ -186,7 +186,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 };
 

--- a/pages/tutorials/[...slug].tsx
+++ b/pages/tutorials/[...slug].tsx
@@ -303,8 +303,7 @@ export const getStaticProps: GetStaticProps<StaticPageProps> = async ({
       props: {
         ...layoutProps,
         source: markup,
-      },
-      revalidate: 60,
+      }
     };
   } catch (e) {
     console.log(e);

--- a/pages/tutorials/[...slug].tsx
+++ b/pages/tutorials/[...slug].tsx
@@ -185,7 +185,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 };
 

--- a/pages/tutorials/[...slug].tsx
+++ b/pages/tutorials/[...slug].tsx
@@ -185,7 +185,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: 'blocking',
+    fallback: true,
   };
 };
 
@@ -304,7 +304,7 @@ export const getStaticProps: GetStaticProps<StaticPageProps> = async ({
         ...layoutProps,
         source: markup,
       },
-      revalidate: 3600,
+      revalidate: 60,
     };
   } catch (e) {
     console.log(e);

--- a/pages/tutorials/[...slug].tsx
+++ b/pages/tutorials/[...slug].tsx
@@ -185,7 +185,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true,
+    fallback: false,
   };
 };
 


### PR DESCRIPTION
2 Tutorials: Table QA and Document Classification at Indexing were left out.
This PR adds them to `latest` and `v1.4.0`