### PR TITLE
[CI] Check for broken links in the current commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: 'build-test'
+on:
+  # rebuild at every commit on PRs and main branch
+  pull_request:
+  push:
+    branches:
+      - source
+
+
+jobs:
+  # Build the NextJS app and Run the link checker
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn haystack
+      - run: yarn build
+      - run: yarn start &
+      - run: yarn linkcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,5 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - run: yarn haystack
-      - run: yarn build
-      - run: yarn start &
+      - run: yarn dev &
       - run: yarn linkcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,6 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - run: yarn haystack
-      - run: yarn dev &
+      - run: yarn build
+      - run: yarn start &
       - run: yarn linkcheck

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # testing
 /coverage
+linkcheck.log
 
 # next.js
 /.next/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest --watch",
-    "test:ci": "jest --ci"
+    "test:ci": "jest --ci",
+    "linkcheck": "ts-node --skipProject ./scripts/linkcheck.ts"
   },
   "dependencies": {
     "@headlessui/react": "^1.4.0",
@@ -64,6 +65,7 @@
     "postcss": "^8.3.6",
     "prop-types": ">=15",
     "tailwindcss": "^2.2.7",
+    "ts-node": "^10.7.0",
     "typescript": "4.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "next lint",
     "test": "jest --watch",
     "test:ci": "jest --ci",
-    "linkcheck": "ts-node --skipProject ./scripts/linkcheck.ts"
+    "linkcheck": "ts-node ./scripts/linkcheck.ts"
   },
   "dependencies": {
     "@headlessui/react": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "haystack": "git clone https://github.com/deepset-ai/haystack.git",
+    "haystack": "git clone -–depth 1 https://github.com/deepset-ai/haystack.git",
     "dev": "next dev",
     "dev:watch": "next-remote-watch ./docs",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "haystack": "git clone -–depth 1 https://github.com/deepset-ai/haystack.git",
+    "haystack": "git clone --depth 1 https://github.com/deepset-ai/haystack.git",
     "dev": "next dev",
     "dev:watch": "next-remote-watch ./docs",
     "build": "next build",

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -1,5 +1,5 @@
 import { green, red } from "chalk";
-import { exec } from "child_process";
+import { execSync } from "child_process";
 import * as fs from "fs";
 import { getHaystackReleaseTagNames } from "../lib/github";
 
@@ -11,7 +11,6 @@ async function main() {
   versions = versions.filter((tagName) => tagName.startsWith("v"));
   // prepend `latest` version, i.e. no version string in the URL
   versions = [""].concat(versions);
-  console.log(versions);
 
   var success: boolean = true;
   for (var version of versions) {
@@ -19,18 +18,17 @@ async function main() {
     const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
 
     console.log(`Crawling ${localUrl} recursively...`);
-    exec(cmd, (error, stdout, stderr) => {
-      const crawlingLogs: string = fs.readFileSync(logFile, "utf8");
-      const idx: number = crawlingLogs.search(/Found \d+ broken link[s]?\./g);
-      if (idx != -1) {
-        console.log(
-          red(`error checking ${localUrl}: `) + crawlingLogs.substring(idx)
-        );
-        success = false;
-      }
+    execSync(cmd);
+    const crawlingLogs: string = fs.readFileSync(logFile, "utf8");
+    const idx: number = crawlingLogs.search(/Found \d+ broken link[s]?\./g);
+    if (idx != -1) {
+      console.log(
+        red(`error checking ${localUrl}: `) + crawlingLogs.substring(idx)
+      );
+      success = false;
+    }
 
-      console.log(green("success ") + `No broken links found in ${localUrl}`);
-    });
+    console.log(green("success ") + `No broken links found in ${localUrl}`);
   }
 
   // fail the check if even one URL has broken links

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 const logFile: string = "linkcheck.log";
 const localUrl: string = "http://localhost:3000";
 const excludeDomains: string = "googletagmanager.com";
-const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
+const cmd: string = `wget --spider -r -nd -nv -H -l 1 -w 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
 
 console.log(`Crawling ${localUrl} recursively...`);
 

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -1,22 +1,38 @@
 import { green, red } from "chalk";
 import { exec } from "child_process";
 import * as fs from "fs";
+import { getHaystackReleaseTagNames } from "../lib/github";
 
-const logFile: string = "linkcheck.log";
-const localUrl: string = "http://localhost:3000";
-const excludeDomains: string = "googletagmanager.com";
-const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
+async function main() {
+  const logFile: string = "linkcheck.log";
+  const excludeDomains: string = "googletagmanager.com";
 
-console.log(`Crawling ${localUrl} recursively...`);
+  var versions = await getHaystackReleaseTagNames();
+  versions = versions.filter((tagName) => tagName.startsWith("v"));
+  versions = versions.slice(0, 5);
+  // prepend `latest` version, i.e. no version string in the URL
+  versions = [""].concat(versions);
+  console.log(versions);
 
-exec(cmd, (error, stdout, stderr) => {
-  const crawlingLogs: string = fs.readFileSync(logFile, "utf8");
-  const idx: number = crawlingLogs.search(/Found \d+ broken link[s]?\./g);
-  if (idx != -1) {
-    console.log(red("error ") + crawlingLogs.substring(idx));
-    process.exitCode = 1;
-    return;
+  for (var version of versions) {
+    const localUrl: string = `http://localhost:3000/overview/${version}/intro`;
+    const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
+
+    console.log(`Crawling ${localUrl} recursively...`);
+    exec(cmd, (error, stdout, stderr) => {
+      const crawlingLogs: string = fs.readFileSync(logFile, "utf8");
+      const idx: number = crawlingLogs.search(/Found \d+ broken link[s]?\./g);
+      if (idx != -1) {
+        console.log(
+          red(`error checking ${localUrl}: `) + crawlingLogs.substring(idx)
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      console.log(green("success ") + `No broken links found in ${localUrl}`);
+    });
   }
+}
 
-  console.log(green("success ") + "No broken links found.");
-});
+main();

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -1,0 +1,22 @@
+import { green, red } from "chalk";
+import { exec } from "child_process";
+import * as fs from "fs";
+
+const logFile: string = "linkcheck.log";
+const localUrl: string = "http://localhost:3000";
+const excludeDomains: string = "googletagmanager.com";
+const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
+
+console.log(`Crawling ${localUrl} recursively...`);
+
+exec(cmd, (error, stdout, stderr) => {
+  const crawlingLogs: string = fs.readFileSync(logFile, "utf8");
+  const idx: number = crawlingLogs.search(/Found \d+ broken link[s]?\./g);
+  if (idx != -1) {
+    console.log(red("error ") + crawlingLogs.substring(idx));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(green("success ") + "No broken links found.");
+});

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -9,7 +9,6 @@ async function main() {
 
   var versions = await getHaystackReleaseTagNames();
   versions = versions.filter((tagName) => tagName.startsWith("v"));
-  versions = versions.slice(0, 5);
   // prepend `latest` version, i.e. no version string in the URL
   versions = [""].concat(versions);
   console.log(versions);

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 const logFile: string = "linkcheck.log";
 const localUrl: string = "http://localhost:3000";
 const excludeDomains: string = "googletagmanager.com";
-const cmd: string = `wget --spider -r -nd -nv -H -l 1 -w 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
+const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
 
 console.log(`Crawling ${localUrl} recursively...`);
 

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -13,6 +13,7 @@ async function main() {
   versions = [""].concat(versions);
   console.log(versions);
 
+  var success: boolean = true;
   for (var version of versions) {
     const localUrl: string = `http://localhost:3000/overview/${version}/intro`;
     const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
@@ -25,12 +26,17 @@ async function main() {
         console.log(
           red(`error checking ${localUrl}: `) + crawlingLogs.substring(idx)
         );
-        process.exitCode = 1;
-        return;
+        success = false;
       }
 
       console.log(green("success ") + `No broken links found in ${localUrl}`);
     });
+  }
+
+  // fail the check if even one URL has broken links
+  if (!success) {
+    process.exitCode = 1;
+    return;
   }
 }
 

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -20,6 +20,7 @@ async function main() {
     console.log(`Crawling ${localUrl} recursively...`);
     try {
       execSync(cmd);
+      console.log(green("success ") + `No broken links found in ${localUrl}`);
     } catch (err) {
       console.log(red(err));
     }
@@ -32,8 +33,6 @@ async function main() {
       );
       success = false;
     }
-
-    console.log(green("success ") + `No broken links found in ${localUrl}`);
   }
 
   // fail the check if even one URL has broken links

--- a/scripts/linkcheck.ts
+++ b/scripts/linkcheck.ts
@@ -15,10 +15,15 @@ async function main() {
   var success: boolean = true;
   for (var version of versions) {
     const localUrl: string = `http://localhost:3000/overview/${version}/intro`;
-    const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile}  ${localUrl}`;
+    const cmd: string = `wget --spider -r -nd -nv -H -l 1 --exclude-domains ${excludeDomains} -o ${logFile} ${localUrl}`;
 
     console.log(`Crawling ${localUrl} recursively...`);
-    execSync(cmd);
+    try {
+      execSync(cmd);
+    } catch (err) {
+      console.log(red(err));
+    }
+
     const crawlingLogs: string = fs.readFileSync(logFile, "utf8");
     const idx: number = crawlingLogs.search(/Found \d+ broken link[s]?\./g);
     if (idx != -1) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,11 @@
     "jsx": "preserve"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "ts-node": {
+    // these options are overrides used only by ts-node
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6061,7 +6061,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@>=15, prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,18 @@
   resolved "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-2.6.148.tgz"
   integrity sha512-6QMz0/2h5C3ua51iAnXMPWFbb1QOU1UvSM4bKBw5mzdT+WtLgjbETBBIQZ+Sh9WvEcGwlAt/DEdRpIC3XlDBMA==
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz"
@@ -1106,6 +1118,26 @@
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/aws-lambda@^8.10.83":
   version "8.10.90"
   resolved "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.90.tgz"
@@ -1423,6 +1455,11 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.0.0, acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
@@ -1432,6 +1469,11 @@ acorn@^8.2.4:
   version "8.7.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+acorn@^8.4.1:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
+  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 agent-base@6:
   version "6.0.2"
@@ -1516,6 +1558,11 @@ anymatch@^3.0.3, anymatch@~3.1.1, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arg@^5.0.1:
   version "5.0.1"
@@ -2344,6 +2391,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@^3.1.4:
   version "3.1.5"
   resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz"
@@ -2599,6 +2651,11 @@ diff-sequences@^27.4.0:
   version "27.4.0"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz"
   integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -5072,6 +5129,11 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 makeerror@1.0.12:
   version "1.0.12"
   resolved "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz"
@@ -5999,7 +6061,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@>=15, prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7310,6 +7372,25 @@ trough@^2.0.0:
   resolved "https://registry.npmjs.org/trough/-/trough-2.0.2.tgz"
   integrity sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w==
 
+ts-node@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
+  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz"
@@ -7662,6 +7743,11 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
+v8-compile-cache-lib@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz"
@@ -7947,6 +8033,11 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
**NOTE:** checks are failing for good reason, we do still have some broken links

We don’t have any test on the NextJS application implementing Haystack website. The only sanity check is indirectly performed by the Vercel deployment, that has to invoke `yarn build` and might eventually fail, surfacing an issue. This is better than nothing but still not enough, as we don’t know if a successful build provides a healthy website: NextJS has an internal router that might return 404 if a page couldn’t be found, but:

- The error might be in the build process but for some reason the it wasn’t propagated
- The error might be in the source link (human error)

## Solution

Use a Github action to build the site at each commit, start the NextJS internal web server and use `wget` to crawl the website, failing the workflow if any link at `depth=1` is broken.

The link checker is written in Typescript and can be run locally with `yarn linkcheck`

### Implementation notes

- `wget` has the `--spider` mode that supports our use case and is available in Github Linux runners
- The check logic is the following:
    - We let `wget` crawl the site and store the results in a log file with `--o`
    - We then read the file looking for errors
    - If errors are found, we print on `stdout` the list of links that failed and exit with return code `1`
    - if no errors are found, a friendly message is printed on `stdout` and the process exits with `0`