### PR TITLE
Fix wrong import

### DIFF
--- a/docs/latest/pipeline_nodes/join_documents.mdx
+++ b/docs/latest/pipeline_nodes/join_documents.mdx
@@ -17,7 +17,7 @@ To use JoinDocuments in a Pipeline, run the following.
 Here the outputs of the ESRetriever and the DPRRetriever are combined by JoinDocuments.
 
 ```python
-from haystack.nodes import Pipeline
+from haystack.pipelines import Pipeline
 from haystack.nodes import JoinDocuments, QueryClassifier
 
 join_documents = JoinDocuments(


### PR DESCRIPTION
This fixes the import of the `Pipeline` in the `JoinDocuments` tutorial.