### PR TITLE
Replace convert_files_to_dicts with convert_files_to_docs

### DIFF
--- a/docs/latest/pipeline_nodes/file_converters.mdx
+++ b/docs/latest/pipeline_nodes/file_converters.mdx
@@ -118,12 +118,12 @@ Click a tab to read more about each converter and see how to initialize it:
   ]}
 />
 
-Haystack also has a `convert_files_to_dicts()` utility function that
+Haystack also has a `convert_files_to_docs()` utility function that
 will convert all txt or pdf files in a given directory.
 
 ```
-from haystack.utils import convert_files_to_dicts
-docs = convert_files_to_dicts(dir_path=doc_dir)
+from haystack.utils.preprocessing import convert_files_to_docs
+docs = convert_files_to_docs(dir_path=doc_dir)
 ```
 
 <div style={{ marginBottom: "3rem" }} />

--- a/docs/v1.4.0/pipeline_nodes/file_converters.mdx
+++ b/docs/v1.4.0/pipeline_nodes/file_converters.mdx
@@ -118,12 +118,12 @@ Click a tab to read more about each converter and see how to initialize it:
   ]}
 />
 
-Haystack also has a `convert_files_to_dicts()` utility function that
+Haystack also has a `convert_files_to_docs()` utility function that
 will convert all txt or pdf files in a given directory.
 
 ```
-from haystack.utils import convert_files_to_dicts
-docs = convert_files_to_dicts(dir_path=doc_dir)
+from haystack.utils.preprocessing import convert_files_to_docs
+docs = convert_files_to_docs(dir_path=doc_dir)
 ```
 
 <div style={{ marginBottom: "3rem" }} />


### PR DESCRIPTION
As pointed out by a community member, our documentation still mentions the `convert_files_to_dicts` method although it has been replaced by `convert_files_to_docs`. We did this a few days after the release of v1.3.0. Therefore, this PR makes changes to the documentation of v1.4.0 and latest. https://github.com/deepset-ai/haystack/discussions/2596