### PR TITLE
Mention required version of Weaviate

### DIFF
--- a/docs/latest/components/document_store.mdx
+++ b/docs/latest/components/document_store.mdx
@@ -148,7 +148,7 @@ Initialising a new DocumentStore within Haystack is straightforward.
             title: "Weaviate",
             content: (
                 <div>
-                The WeaviateDocumentStore requires a running Weaviate Server.
+                The WeaviateDocumentStore requires a running Weaviate Server version 1.8 or later.
                 You can start a basic instance like this (see the <a href="https://www.semi.technology/developers/weaviate/current/">Weaviate docs</a> for details):
                 <pre>
                     <code>docker run -d -p 8080:8080 --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' semitechnologies/weaviate:1.12.0</code>

--- a/docs/v1.4.0/components/document_store.mdx
+++ b/docs/v1.4.0/components/document_store.mdx
@@ -148,7 +148,7 @@ Initialising a new DocumentStore within Haystack is straightforward.
             title: "Weaviate",
             content: (
                 <div>
-                The WeaviateDocumentStore requires a running Weaviate Server.
+                The WeaviateDocumentStore requires a running Weaviate Server version 1.8 or later.
                 You can start a basic instance like this (see the <a href="https://www.semi.technology/developers/weaviate/current/">Weaviate docs</a> for details):
                 <pre>
                     <code>docker run -d -p 8080:8080 --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' semitechnologies/weaviate:1.12.0</code>


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/haystack/issues/2594

With https://github.com/deepset-ai/haystack/pull/1895 we introduced support for results pagination, that was shipped
with Haystack v1.14.

The `offset` parameter was [introduced in Weaviate 1.8](https://github.com/semi-technologies/weaviate/releases/tag/v1.8.0), so Haystack 1.4 will raise an error when using an older version of the database.