### PR TITLE
Missing 1.5.0 links in documentation

### DIFF
--- a/docs/latest/menu.json
+++ b/docs/latest/menu.json
@@ -35,6 +35,8 @@
     "pathPrefix": "/pipeline_nodes/",
     "items": [
       {"slug": "overview", "title": "Overview"},
+      {"slug": "answer-to-speech", "title": "AnswerToSpeech"},
+      {"slug": "document-to-speech", "title": "DocumentToSpeech"},
       {"slug": "preprocessor", "title": "PreProcessor"},
       {"slug": "file-converters", "title": "File Converters"},
       {"slug": "crawler", "title": "Crawler"},

--- a/docs/latest/pipeline_nodes/answer_to_speech.mdx
+++ b/docs/latest/pipeline_nodes/answer_to_speech.mdx
@@ -1,0 +1,40 @@
+# AnswerToSpeech
+
+Use this node in question-answering pipelines to convert text Answers into AudioAnswers. AudioAnswers and their content are read out into an audio file. 
+
+This node is experimental because of the dataclasses it uses (`GeneratedAudioAnswer`). Bear in mind that that they might change in the future. 
+
+|||
+|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|__Position in a Pipeline__| The last node in the pipeline, after a Reader |
+|__Input__       | Answer                                                                                                                                                                  |
+|__Output__      | GeneratedAudioAnswer                                                                                                             |
+|__Classes__     | AnswerToSpeech                                                                                                          |
+|||
+
+## Usage
+To initialize `AnswerToSpeech`, run:
+```python
+from haystack.nodes import AnswerToSpeech
+
+model_name = 'espnet/kan-bayashi_ljspeech_vits'
+answer_dir = './generated_audio_answers'
+
+audio_answer = AnswerToSpeech(model_name_or_path=model_name, generated_audio_dir=answer_dir)
+```
+To use `AnswerToSpeech` in a pipeline, run:
+```python
+from haystack.nodes import AnswerToSpeech
+
+retriever = BM25Retriever(document_store=document_store)
+reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
+answer2speech = AnswerToSpeech(
+    model_name_or_path="espnet/kan-bayashi_ljspeech_vits",
+    generated_audio_dir=Path(__file__).parent / "audio_answers",
+    )
+
+audio_pipeline = Pipeline()
+audio_pipeline.add_node(retriever, name="Retriever", inputs=["Query"])
+audio_pipeline.add_node(reader, name="Reader", inputs=["Retriever"])
+audio_pipeline.add_node(answer2speech, name="AnswerToSpeech", inputs=["Reader"])
+```

--- a/docs/latest/pipeline_nodes/answer_to_speech.mdx
+++ b/docs/latest/pipeline_nodes/answer_to_speech.mdx
@@ -1,14 +1,14 @@
 # AnswerToSpeech
 
-Use this node in question-answering pipelines to convert text Answers into AudioAnswers. AudioAnswers and their content are read out into an audio file. 
+Use this node in question-answering pipelines to convert text Answers into SpeechAnswers. The answer and its context are read out into two audio files. 
 
-This node is experimental because of the dataclasses it uses (`GeneratedAudioAnswer`). Bear in mind that that they might change in the future. 
+This node is experimental because of the dataclasses it uses (`SpeechAnswer`). Bear in mind that that they might change in the future. 
 
 |||
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |__Position in a Pipeline__| The last node in the pipeline, after a Reader |
 |__Input__       | Answer                                                                                                                                                                  |
-|__Output__      | GeneratedAudioAnswer                                                                                                             |
+|__Output__      | SpeechAnswer                                                                                                             |
 |__Classes__     | AnswerToSpeech                                                                                                          |
 |||
 

--- a/docs/latest/pipeline_nodes/document_to_speech.mdx
+++ b/docs/latest/pipeline_nodes/document_to_speech.mdx
@@ -27,7 +27,6 @@ To use `DocumentToSpeech` in a pipeline, run:
 from haystack.nodes import DocumentToSpeech
 
 retriever = BM25Retriever(document_store=document_store)
-reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
 document2speech = DocumentToSpeech(
     model_name_or_path="espnet/kan-bayashi_ljspeech_vits",
     generated_audio_dir=Path(__file__).parent / "audio_documents",
@@ -35,6 +34,5 @@ document2speech = DocumentToSpeech(
 
 audio_pipeline = Pipeline()
 audio_pipeline.add_node(retriever, name="Retriever", inputs=["Query"])
-audio_pipeline.add_node(reader, name="Reader", inputs=["Retriever"])
-audio_pipeline.add_node(document2speech, name="DocumentToSpeech", inputs=["Reader"])
+audio_pipeline.add_node(document2speech, name="DocumentToSpeech", inputs=["Retriever"])
 ```

--- a/docs/latest/pipeline_nodes/document_to_speech.mdx
+++ b/docs/latest/pipeline_nodes/document_to_speech.mdx
@@ -6,7 +6,7 @@ This node is experimental because of the dataclasses it uses (`SpeechDocument`).
 
 |||
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|__Position in a Pipeline__| The last node in the pipeline, after a Retriever |
+|__Position in a Pipeline__| The last node in a document search pipeline, after a Retriever in a single-Retriever pipeline; or at the end of an indexing pipeline, before the Document Store |
 |__Input__       | Document                                                                                                                                                                  |
 |__Output__      | SpeechDocument                                                                                                             |
 |__Classes__     | DocumentToSpeech                                                                                                         |
@@ -35,4 +35,33 @@ document2speech = DocumentToSpeech(
 audio_pipeline = Pipeline()
 audio_pipeline.add_node(retriever, name="Retriever", inputs=["Query"])
 audio_pipeline.add_node(document2speech, name="DocumentToSpeech", inputs=["Retriever"])
+```
+Here's an example of an indexing pipeline with `DocumentToSpeech`:
+```python
+file_paths = [p for p in Path(documents_path).glob("**/*")]
+
+indexing_pipeline = Pipeline()
+
+classifier = FileTypeClassifier()
+indexing_pipeline.add_node(classifier, name="classifier", inputs=["File"])
+
+text_converter = TextConverter(remove_numeric_tables=True)
+indexing_pipeline.add_node(text_converter, name="text_converter", inputs=["classifier.output_1"])
+
+preprocessor = PreProcessor(
+        clean_whitespace=True,
+        clean_empty_lines=True,
+        split_length=100,
+        split_overlap=50,
+        split_respect_sentence_boundary=True,
+)
+indexing_pipeline.add_node(preprocessor, name="preprocessor", inputs=["text_converter"])
+
+doc2speech = DocumentToSpeech(model_name_or_path="espnet/kan-bayashi_ljspeech_vits", generated_audio_dir=Path("./audio_documents"))
+indexing_pipeline.add_node(doc2speech, name="doc2speech", inputs=["preprocessor"])
+
+document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
+indexing_pipeline.add_node(document_store, name="document_store", inputs=["doc2speech"])
+
+indexing_pipeline.run(file_paths=file_paths, meta=files_metadata)
 ```

--- a/docs/latest/pipeline_nodes/document_to_speech.mdx
+++ b/docs/latest/pipeline_nodes/document_to_speech.mdx
@@ -1,0 +1,40 @@
+# DocumentToSpeech
+
+Use this node in document retrieval pipelines to convert text Documents into AudioDocuments. AudioDocuments and their content are read out into an audio file. 
+
+This node is experimental because of the dataclasses it uses (`GeneratedAudioDocument`). Bear in mind that that they might change in the future. 
+
+|||
+|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|__Position in a Pipeline__| The last node in the pipeline, after a Reader |
+|__Input__       | Document                                                                                                                                                                  |
+|__Output__      | GeneratedAudioDocument                                                                                                             |
+|__Classes__     | DocumentToSpeech                                                                                                         |
+|||
+
+## Usage
+To initialize `DocumentToSpeech`, run:
+```python
+from haystack.nodes import DocumentToSpeech
+
+model_name = 'espnet/kan-bayashi_ljspeech_vits'
+answer_dir = './generated_audio_answers'
+
+audio_document = DocumentToSpeech(model_name_or_path=model_name, generated_audio_dir=answer_dir)
+```
+To use `DocumentToSpeech` in a pipeline, run:
+```python
+from haystack.nodes import DocumentToSpeech
+
+retriever = BM25Retriever(document_store=document_store)
+reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
+document2speech = DocumentToSpeech(
+    model_name_or_path="espnet/kan-bayashi_ljspeech_vits",
+    generated_audio_dir=Path(__file__).parent / "audio_documents",
+    )
+
+audio_pipeline = Pipeline()
+audio_pipeline.add_node(retriever, name="Retriever", inputs=["Query"])
+audio_pipeline.add_node(reader, name="Reader", inputs=["Retriever"])
+audio_pipeline.add_node(document2speech, name="DocumentToSpeech", inputs=["Reader"])
+```

--- a/docs/latest/pipeline_nodes/document_to_speech.mdx
+++ b/docs/latest/pipeline_nodes/document_to_speech.mdx
@@ -1,14 +1,14 @@
 # DocumentToSpeech
 
-Use this node in document retrieval pipelines to convert text Documents into AudioDocuments. AudioDocuments and their content are read out into an audio file. 
+Use this node in document retrieval pipelines to convert text Documents into SpeechDocuments. The document's content is read out into an audio file. 
 
-This node is experimental because of the dataclasses it uses (`GeneratedAudioDocument`). Bear in mind that that they might change in the future. 
+This node is experimental because of the dataclasses it uses (`SpeechDocument`). Bear in mind that that they might change in the future. 
 
 |||
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|__Position in a Pipeline__| The last node in the pipeline, after a Reader |
+|__Position in a Pipeline__| The last node in the pipeline, after a Retriever |
 |__Input__       | Document                                                                                                                                                                  |
-|__Output__      | GeneratedAudioDocument                                                                                                             |
+|__Output__      | SpeechDocument                                                                                                             |
 |__Classes__     | DocumentToSpeech                                                                                                         |
 |||
 

--- a/docs/v1.5.0/components/pipelines.mdx
+++ b/docs/v1.5.0/components/pipelines.mdx
@@ -328,7 +328,7 @@ An update to the Haystack version might require small updates to the YAML files.
 
 ## Ready-Made Pipelines
 
-Last but not least, we added some ready-made pipelines that you can use to run standard patterns with very few lines of code. To learn more about these, see the [ready-made pipelines page](/components/ready-made-pipelines) and [pipelines API documentation](/reference/pipelines).
+Last but not least, we added some ready-made pipelines that you can use to run standard patterns with very few lines of code. To learn more about these, see the [ready-made pipelines page](/components/v1.5.0/ready-made-pipelines) and [pipelines API documentation](/reference/v1.5.0/pipelines).
 
 **Examples:**
 

--- a/docs/v1.5.0/components/ready_made_pipelines.mdx
+++ b/docs/v1.5.0/components/ready_made_pipelines.mdx
@@ -190,7 +190,7 @@ result['documents']
 
 Translator components bring the power of machine translation into your QA systems. Say your knowledge base is in English but the majority of your user base speaks German. With a `TranslationWrapperPipeline`, you can chain together:
 
-- The [Translator](/pipeline_nodes/translator), which translates a query source into a target language (e.g. German into English)
+- The [Translator](/pipeline_nodes/v1.5.0/translator), which translates a query source into a target language (e.g. German into English)
 - A search pipeline such as ExtractiveQAPipeline or DocumentSearchPipeline, which executes the translated query against a knowledge base.
 - Another Translator that translates the search pipeline's results from the target back into the source language (e.g. English into German)
 
@@ -296,5 +296,5 @@ msd_pipeline = MostSimilarDocumentsPipeline(document_store)
 result = msd_pipeline.run(document_ids=[doc_id1, doc_id2, ...])
 ```
 
-The output will be a list of [Document](/components/documents-answers-labels#document) objects.
+The output will be a list of [Document](/components/v1.5.0/documents-answers-labels#document) objects.
 

--- a/docs/v1.5.0/components/rest_api.mdx
+++ b/docs/v1.5.0/components/rest_api.mdx
@@ -89,7 +89,7 @@ There are two options for indexing answers when working with an empty datastore.
 
 #### Option 1: Using an indexing script
 
-You can load documents to your datastore by using a Python script that runs before the Haystack API is initialized. You can find an example script that pre-processes a few files and saves them into the document store in the [Build Your First QA System tutorial](https://haystack.deepset.ai/docs/tutorial1md#Preprocessing-of-documents).
+You can load documents to your datastore by using a Python script that runs before the Haystack API is initialized. You can find an example script that pre-processes a few files and saves them into the document store in the [Build Your First QA System tutorial](tutorials/v1.5.0/tutorial1md#Preprocessing-of-documents).
 
 If you go with an indexing script, your REST API startup flow would be:
 

--- a/docs/v1.5.0/components/rest_api_definition.mdx
+++ b/docs/v1.5.0/components/rest_api_definition.mdx
@@ -2,7 +2,7 @@
 
 Here are the endpoint definitions of the latest master version of Haystack.
 To find the definitions of the REST API that you are running,
-see [Swagger documentation for the Haystack REST API](/components/rest-api#swagger-documentation-for-the-haystack-rest-api).
+see [Swagger documentation for the Haystack REST API](/components/v1.5.0/rest-api#swagger-documentation-for-the-haystack-rest-api).
 
 <div>
     <Swagger />

--- a/docs/v1.5.0/guides/chatbots.mdx
+++ b/docs/v1.5.0/guides/chatbots.mdx
@@ -21,7 +21,7 @@ When it receives the result, it will base its next message to the user on the co
 
 ## Setting up Haystack with REST API
 
-To set up a Haystack instance with REST API, have a look at [this documentation page](/components/rest-api).
+To set up a Haystack instance with REST API, have a look at [this documentation page](/components/v1.5.0/rest-api).
 By default, the API server runs on `http://127.0.0.1:8000`.
 
 <div className="max-w-xl bg-yellow-light-theme border-l-8 border-yellow-dark-theme px-6 pt-6 pb-4 my-4 rounded-md dark:bg-yellow-900">

--- a/docs/v1.5.0/guides/knowledge_graph.mdx
+++ b/docs/v1.5.0/guides/knowledge_graph.mdx
@@ -26,7 +26,7 @@ Similar to Haystack's ElasticsearchDocumentStore, the only additional setting ne
 `kg = GraphDBKnowledgeGraph(index="tutorial_10_index")`
 
 Indices can be deleted and created with `GraphDBKnowledgeGraph.delete_index()` and `GraphDBKnowledgeGraph.create_index(config_path)`.
-`config_path` needs to point to a .ttl file that contains configuration settings (see [GraphDB documentation](https://graphdb.ontotext.com/documentation/free/configuring-a-repository.html#configure-a-repository-programmatically) for details or use the file from our [tutorial](/tutorials/knowledge-graph)). It starts with something like:
+`config_path` needs to point to a .ttl file that contains configuration settings (see [GraphDB documentation](https://graphdb.ontotext.com/documentation/free/configuring-a-repository.html#configure-a-repository-programmatically) for details or use the file from our [tutorial](/tutorials/v1.5.0/knowledge-graph)). It starts with something like:
 
 ```
 #

--- a/docs/v1.5.0/pipeline_nodes/crawler.mdx
+++ b/docs/v1.5.0/pipeline_nodes/crawler.mdx
@@ -8,7 +8,7 @@ For example, you can use the Crawler if you want to add the contents of a websit
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |__Position in a Pipeline__| At the very beginning of an indexing Pipeline |
 |__Input__       | Files                                                                                                                                                                  |
-|__Output__      | [Documents](/components/documents-answers-labels#document)                                                                                                             |
+|__Output__      | [Documents](/components/v1.5.0/documents-answers-labels#document)                                                                                                             |
 |__Classes__     | Crawler                                                                                                          |
 |||
 

--- a/docs/v1.5.0/pipeline_nodes/docs2answers.mdx
+++ b/docs/v1.5.0/pipeline_nodes/docs2answers.mdx
@@ -5,8 +5,8 @@ Doc2Answers converts retrieved Documents into Answers. It is useful if you have 
 |||
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |__Position in a Pipeline__| At the end of a querying Pipeline |
-|__Input__       | [Documents](/components/documents-answers-labels#document)                                                                                                                                                                  |
-|__Output__      | [Answers](/components/documents-answers-labels#answer)                                                                                                             |
+|__Input__       | [Documents](/components/v1.5.0/documents-answers-labels#document)                                                                                                                                                                  |
+|__Output__      | [Answers](/components/v1.5.0/documents-answers-labels#answer)                                                                                                             |
 |__Classes__     | Docs2Answers                                                                                                        |
 |||
 

--- a/docs/v1.5.0/pipeline_nodes/document_classifier.mdx
+++ b/docs/v1.5.0/pipeline_nodes/document_classifier.mdx
@@ -7,8 +7,8 @@ Thanks to tight integration with the Hugging Face model hub, you can supply a mo
 |||
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |__Position in a Pipeline__| After the PreProcessor in an indexing Pipeline or after a Retriever in a query Pipeline for classification on the fly |
-|__Input__       | [Documents](/components/documents-answers-labels#document)                                                                                                                                                                   |
-|__Output__      | [Documents](/components/documents-answers-labels#document)                                                                                                                                                                     |
+|__Input__       | [Documents](/components/v1.5.0/documents-answers-labels#document)                                                                                                                                                                   |
+|__Output__      | [Documents](/components/v1.5.0/documents-answers-labels#document)                                                                                                                                                                     |
 |__Classes__     | TransformersDocumentClassifier                                                                                                                                             |
 |||
 

--- a/docs/v1.5.0/pipeline_nodes/entity_extractor.mdx
+++ b/docs/v1.5.0/pipeline_nodes/entity_extractor.mdx
@@ -6,8 +6,8 @@ Its most common use case is Named Entity Extraction (NER) but you can also use i
 |||
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |__Position in a Pipeline__| After the PreProcessor in an indexing Pipeline or after a Retriever in a query Pipeline for extraction on the fly |
-|__Input__       | [Documents](/components/documents-answers-labels#document)                                                                                                                                                                   |
-|__Output__      | [Documents](/components/documents-answers-labels#document)                                                                                                                                                                     |
+|__Input__       | [Documents](/components/1.5/documents-answers-labels#document)                                                                                                                                                                   |
+|__Output__      | [Documents](/components/1.5/documents-answers-labels#document)                                                                                                                                                                     |
 |__Classes__     | EntityExtractor                                                                                                                                             |
 |||
 

--- a/docs/v1.5.0/pipeline_nodes/file_converters.mdx
+++ b/docs/v1.5.0/pipeline_nodes/file_converters.mdx
@@ -7,7 +7,7 @@ in different formats and cast it into the unified Document format.
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |__Position in a Pipeline__| At the very beginning of an indexing Pipeline |
 |__Input__       | Filename                                                                                                                                                                  |
-|__Output__      | [Documents](/components/documents-answers-labels#document)                                                                                                             |
+|__Output__      | [Documents](/components/v1.5.0/documents-answers-labels#document)                                                                                                             |
 |__Classes__     | PDFToTextConverter<br />PDFToTextOCRConverter<br />DocxToTextConverter<br />AzureConverter<br />ImageToTextConverter<br />MarkdownConverter<br />ParsrConverter<br />TikaConverter<br />TextConverter<br />                                                                                                           |
 |||
 

--- a/docs/v1.5.0/pipeline_nodes/join_answers.mdx
+++ b/docs/v1.5.0/pipeline_nodes/join_answers.mdx
@@ -5,8 +5,8 @@ The `JoinAnswers` node takes Answers from two or more Reader or Generator nodes 
 |||
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |__Position in a Pipeline__| Joins the output of two or more Nodes that return Answers |
-|__Input__       | [Answers](/components/documents-answers-labels#answer)                                                                                                                                                                   |
-|__Output__      | [Answers](/components/documents-answers-labels#answer)                                                                                                                                                                     |
+|__Input__       | [Answers](/components/v1.5.0/documents-answers-labels#answer)                                                                                                                                                                   |
+|__Output__      | [Answers](/components/v1.5.0/documents-answers-labels#answer)                                                                                                                                                                     |
 |__Classes__     | JoinAnswers                                                                                                                                             |
 |||
 


### PR DESCRIPTION
Some of the docs in version 1.5.0 had links to the latest version instead of 1.5.0. This PR fixes it.