### PR TITLE
Change fine-tune to domain-adapt in GPL guide

### DIFF
--- a/docs/latest/guides/gpl.mdx
+++ b/docs/latest/guides/gpl.mdx
@@ -48,4 +48,4 @@ psg = PseudoLabelGenerator(qg, retriever)
 output, _ = psg.run(documents=document_store.get_all_documents()) 
 retriever.train(output["gpl_labels"])
 ```
-And that's it! You now have a fine-tuned retriever.
+And that's it! You now have a domain-adapted retriever.


### PR DESCRIPTION
As discussed in a call today, it might be confusing to mention fine-tuning (on a downstream task) here because what we actually do with GPL is domain adaptation. There is a mixed use of the terminology in the community so I wouldn't be too strict about it. Here it clarifies and helps with understanding though in my opinion.