### PR TITLE
Add GPL tutorial to latest docs

### DIFF
--- a/docs/latest/menu.json
+++ b/docs/latest/menu.json
@@ -137,6 +137,10 @@
       {
         "slug": "doc-class-index",
         "title": "Document Classification at Indexing"
+      },
+      {
+        "slug": "gpl",
+        "title": "Use Generative Pseudo Labelling for Domain Adaptation"
       }
     ]
   },

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -200,6 +200,11 @@ export const tutorialFilesLatest: Meta = {
       filename: "16.md",
       title: 'Document Classification at Index',
     },
+    {
+      slug: "gpl",
+      filename: "18.md",
+      title: 'Use Generative Pseudo Labelling for Domain Adaptation',
+    },
   ],
 };
 


### PR DESCRIPTION
GPL was actually added in 1.5.0 release. However, let's first add it to the latest and then in a separate PR make sure that all docs (component/guide/API/tutorial) are added to 1.5.0 as well. 