### PR TITLE
Add audio tutorial to menu

### DIFF
--- a/docs/latest/menu.json
+++ b/docs/latest/menu.json
@@ -141,6 +141,10 @@
         "title": "Document Classification at Indexing"
       },
       {
+        "slug": "audio",
+        "title": "Make Your QA Pipelines Talk with Audio Nodes!"
+      },
+      {
         "slug": "gpl",
         "title": "Use Generative Pseudo Labelling for Domain Adaptation"
       }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -201,6 +201,11 @@ export const tutorialFilesLatest: Meta = {
       title: 'Document Classification at Index',
     },
     {
+      slug: "audio",
+      filename: "17.md",
+      title: 'Make Your QA Pipelines Talk with Audio Nodes!',
+    },
+    {
       slug: "gpl",
       filename: "18.md",
       title: 'Use Generative Pseudo Labelling for Domain Adaptation',


### PR DESCRIPTION
The audio tutorial didn't show up on the website because it wasn't included in the menu. This PR adds the audio tutorial to the menu.