### PR TITLE
Images for twitter thumbnails have to be an accessible URL

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -28,6 +28,7 @@ const Layout: FC<LayoutProps> = ({
     title: "Haystack Docs",
     description: "Haystack enables Question Answering at Scale",
     image: "/img/haystack-logo-colored.png",
+    twitter_image: "https://raw.githubusercontent.com/deepset-ai/haystack-website/source/public/img/haystack-logo-colored.png",
     type: "website",
   };
 
@@ -58,7 +59,7 @@ const Layout: FC<LayoutProps> = ({
         <meta name="twitter:site" content="@deepset_ai" />
         <meta name="twitter:title" content={meta.title} />
         <meta name="twitter:description" content={meta.description} />
-        <meta name="twitter:image" content={meta.image} />
+        <meta name="twitter:image" content={meta.twitter_image} />
       </Head>
       <Header docsType={"haystack"} />
       <DesktopNav menu={menu} />


### PR DESCRIPTION
The thumbnail image for docs wasn't showing on twitter. The reason for this is that twitter images have to be an accessible URL afaik. Trying this out and will see if it works with the URL from Vercel build