### PR TITLE
Fix quotation marks of wrong type

### DIFF
--- a/docs/latest/pipeline_nodes/custom_nodes.mdx
+++ b/docs/latest/pipeline_nodes/custom_nodes.mdx
@@ -83,7 +83,7 @@ This means that if we want to pass a language value to our custom node, we can s
 Let's look at the French summary of a popular wizard sport:
 
 ``` python
-query = "What's the history of Quidditch?'
+query = "What's the history of Quidditch?"
 result = pipeline.run(query=query, params={"retriever": {"top_k": 30}, "ranker": {"top_k": 20}, "language": "fr"})
 result['documents'][0].text
 


### PR DESCRIPTION
Quotation marks were single quotes instead of double quotes, which led to wrong highlighting on the web page. This PR changes the quotation marks so that the highlighting is correct.

Wrong highlighting from before:
<img width="431" alt="image" src="https://user-images.githubusercontent.com/4181769/178467830-6ff4f3b8-9306-45f3-a94a-275f8ac86549.png">
