### PR TITLE
runtime error in filtering example.[fixed]

### DIFF
--- a/docs/latest/guides/metadata_filtering.mdx
+++ b/docs/latest/guides/metadata_filtering.mdx
@@ -95,7 +95,7 @@ This is what the above filter would look like in this style.
         "Date": {"$lt": "2019-01-01"}
         }
     },
-    "$and": {
+    {"$and": {
         "Type": "Blog post",
         "Date": {"$gte": "2019-01-01"}
         }


### PR DESCRIPTION
Someone forgot a "{", in the nested logical operators bit.