### PR TITLE
Fix non-syntactic filter example and format code

### DIFF
--- a/docs/latest/guides/metadata_filtering.mdx
+++ b/docs/latest/guides/metadata_filtering.mdx
@@ -73,14 +73,17 @@ filters = {
 It is not possible to use logical operators twice on the same level since dictionary keys have to be unique.
 For example, the following filter is not valid
 
-```
-{"$or":
-    {"$and": {
-         "Type": "News Paper",
-         "Date": {"$lt": "2019-01-01"},
-     "$and": {      # repeated key in dictionary
-         "Type": "Blog post",
-         "Date": {"$gte": "2019-01-01"}
+``` python
+{
+    "$or": {
+        "$and": {
+            "Type": "News Paper",
+            "Date": {"$lt": "2019-01-01"},
+        },
+        "$and": {      # repeated key in dictionary
+            "Type": "Blog post",
+            "Date": {"$gte": "2019-01-01"}
+        }
     }
 }
 ```
@@ -89,17 +92,21 @@ To get around this, we allow logical operators to take a list of dictionaries as
 This is what the above filter would look like in this style.
 
 ```
-{"$or": [
-    {"$and": {
-        "Type": "News Paper",
-        "Date": {"$lt": "2019-01-01"}
+{
+    "$or": [
+        {
+            "$and": {
+                "Type": "News Paper",
+                "Date": {"$lt": "2019-01-01"}
+            }
+        },
+        {
+            "$and": {
+                "Type": "Blog post",
+                "Date": {"$gte": "2019-01-01"}
+            }
         }
-    },
-    {"$and": {
-        "Type": "Blog post",
-        "Date": {"$gte": "2019-01-01"}
-        }
-    }]
+    ]
 }
 ```
 


### PR DESCRIPTION
Fixes a code example that wasn't syntactic because of a missing set of `{` and `}`. Also formats filter examples so that they are appropriately indented