### PR TITLE
Fixes outdated/bad-links documentation

### DIFF
--- a/docs/latest/components/document_store.mdx
+++ b/docs/latest/components/document_store.mdx
@@ -125,7 +125,7 @@ Initialising a new DocumentStore within Haystack is straightforward.
                 <div>
                 The InMemoryDocumentStore() requires no external setup. Start it by simply using this line.
                 <pre>
-                    <code>from haystack.document_store import InMemoryDocumentStore</code>
+                    <code>from haystack.document_stores import InMemoryDocumentStore</code>
                     <code>document_store = InMemoryDocumentStore()</code>
                 </pre>
                 </div>
@@ -138,7 +138,7 @@ Initialising a new DocumentStore within Haystack is straightforward.
                 The SQLDocumentStore requires SQLite, PostgresQL or MySQL to be installed and started.
                 Note that SQLite already comes packaged with most operating systems.
                 <pre>
-                <code>from haystack.document_store import SQLDocumentStore</code>
+                <code>from haystack.document_stores import SQLDocumentStore</code>
                 <code>document_store = SQLDocumentStore()</code>
                 </pre>
                 </div>

--- a/docs/latest/pipeline_nodes/overview.mdx
+++ b/docs/latest/pipeline_nodes/overview.mdx
@@ -27,7 +27,7 @@ See each individual Node's documentation page to learn more about its available 
 | [Crawler](/pipeline_nodes/crawler)      | Crawler | Scrapes websites and returns text  |
 | [PreProcessor](/pipeline_nodes/preprocessor)      | PreProcessor                                 | Performs cleaning and splitting on Documents   |
 | [Retriever](/pipeline_nodes/retriever)       | BM25Retriever, ElasticsearchRetriever, DensePassageRetriever, TableTextRetriever, EmbeddingRetriever, TfidfRetriever, ElasticsearchFilterOnlyRetriever  | Looks into a coupled Document Store and fetches Documents that are relevant to a given Query  |
-| [Reader](/pipeline_nodes/retriever)      | FARMReader, TransformersReader                      |  Finds an answer to a question by selecting a text span in the provided Documents |
+| [Reader](/pipeline_nodes/reader)      | FARMReader, TransformersReader                      |  Finds an answer to a question by selecting a text span in the provided Documents |
 | [Answer Generator](/pipeline_nodes/answer-generator)      | RAGenerator, Seq2SeqGenerator, OpenAIAnswerGenerator  |  Generates an answer to a question by reading through the provided documents and composing an answer word-by-word |
 | [Summarizer](/pipeline_nodes/summarizer)      | TransformersSummarizer  |  Creates a shorter overview of a given Document |
 | [Translator](/pipeline_nodes/translator)      | TransformersTranslator  |  Translate text from one language into another |


### PR DESCRIPTION
Fixes Reader Node link on Pipelines Nodes Overview page and `from haystack.document_store` to the latest `from haystack.document_stores`

Fixes #395 