### PR TITLE
Sitemap - Exclude versioned paths and their future tracking

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -32,20 +32,6 @@ const Layout: FC<LayoutProps> = ({
     type: "website",
   };
 
-  var canonical_map: { [key: string]: string; } = {};
-  canonical_map["/overview/nlp-resources"] = "/nlp-resources";
-
-  const get_canonical = function (current_path: string) {
-    var canonical = ''
-    if(canonical_map[current_path]){
-      canonical = canonical_map[current_path]
-    }
-    else canonical = current_path;
-    return `https://haystack.deepset.ai${canonical}`;
-  };
-
-  var canonical = get_canonical(router.asPath)
-
   return (
     <div className="dark:bg-gray-800">
       <Head>
@@ -59,7 +45,10 @@ const Layout: FC<LayoutProps> = ({
           property="og:url"
           content={`https://haystack.deepset.ai${router.asPath}`}
         />
-        <link rel="canonical" href={`${canonical}`}/>
+        <link
+          rel="canonical"
+          href={`https://haystack.deepset.ai${router.asPath}`}
+        />
         <link rel="icon" href="/img/HaystackIcon.png" />
         <meta property="og:type" content={meta.type} />
         <meta property="og:site_name" content="Haystack Docs" />

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -59,10 +59,7 @@ const Layout: FC<LayoutProps> = ({
           property="og:url"
           content={`https://haystack.deepset.ai${router.asPath}`}
         />
-        <link
-          rel="canonical"
-          href={`https://haystack.deepset.ai${router.asPath}`}
-        />
+        <link rel="canonical" href={`${canonical}`}/>
         <link rel="icon" href="/img/HaystackIcon.png" />
         <meta property="og:type" content={meta.type} />
         <meta property="og:site_name" content="Haystack Docs" />

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -32,6 +32,20 @@ const Layout: FC<LayoutProps> = ({
     type: "website",
   };
 
+  var canonical_map: { [key: string]: string; } = {};
+  canonical_map["/overview/nlp-resources"] = "/nlp-resources";
+
+  const get_canonical = function (current_path: string) {
+    var canonical = ''
+    if(canonical_map[current_path]){
+      canonical = canonical_map[current_path]
+    }
+    else canonical = current_path;
+    return `https://haystack.deepset.ai${canonical}`;
+  };
+
+  var canonical = get_canonical(router.asPath)
+
   return (
     <div className="dark:bg-gray-800">
       <Head>

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,4 +1,5 @@
 module.exports = {
     siteUrl: process.env.SITE_URL || 'https://haystack.deepset.ai',
     generateRobotsTxt: true, 
+    exclude: ['/tutorials/v*','/overview/v*', '/components/v*', '/usage/*', '/reference/v*', '/guides/v*', '/pipeline_nodes/v*', '/benchmarks/v*']
   }

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,5 +1,10 @@
 module.exports = {
     siteUrl: process.env.SITE_URL || 'https://haystack.deepset.ai',
     generateRobotsTxt: true, 
-    exclude: ['/tutorials/v*','/overview/v*', '/components/v*', '/usage/*', '/reference/v*', '/guides/v*', '/pipeline_nodes/v*', '/benchmarks/v*']
+    exclude: ['/tutorials/v*','/overview/v*', '/components/v*', '/usage/*', '/reference/v*', '/guides/v*', '/pipeline_nodes/v*', '/benchmarks/v*'],
+    robotsTxtOptions: {
+      policies: [
+                 { userAgent: "*", disallow:['/tutorials/v*','/overview/v*', '/components/v*', '/usage/*', '/reference/v*', '/guides/v*', '/pipeline_nodes/v*', '/benchmarks/v*']},
+        ]
+  }
   }


### PR DESCRIPTION
To re-generate the new sitemap we might have to change the build step on Vercel @masci but I am not sure about this. The sitemap is generated with the `postbuild` step (from `package.json`)